### PR TITLE
LPS 25873

### DIFF
--- a/portal-web/docroot/html/js/liferay/asset_tags_selector.js
+++ b/portal-web/docroot/html/js/liferay/asset_tags_selector.js
@@ -556,6 +556,9 @@ AUI.add(
 								if (!autocompleteSearchList) {
 									instance._plugAutocompleteSearchList(entries);
 								}
+								else {
+									autocompleteSearchList.refreshEntries(instance.entries);
+								}
 							}
 						);
 


### PR DESCRIPTION
closing the popup and removing a tag from the input field will now be refreshed when the dialog reappears

I included the comment because calling <code>autocompleteSearchList._initialSearch();</code> doesn't appear to be 100% straightforward and a little hacky.
