### PR TITLE
LPS-29907 - Clicking the save or options icons when adding a page stops working after the first one

### DIFF
--- a/portal-web/docroot/html/js/liferay/navigation.js
+++ b/portal-web/docroot/html/js/liferay/navigation.js
@@ -403,13 +403,15 @@ AUI.add(
 					instance.fire(eventName, options);
 				};
 
+				var comboBoxIconRandomId = Util.randomInt();
+
 				var icons = [
 					{
 						handler: function(event) {
 							comboBox.fire('savePage', options);
 						},
 						icon: 'check',
-						id: 'save'
+						id: 'save_' + comboBoxIconRandomId
 					}
 				];
 
@@ -431,7 +433,7 @@ AUI.add(
 								comboBox._optionsOverlay[action]();
 							},
 							icon: 'gear',
-							id: 'options'
+							id: 'options_' + comboBoxIconRandomId
 						}
 					);
 				}
@@ -487,7 +489,7 @@ AUI.add(
 				).render(listItem);
 
 				if (prototypeTemplate && instance._optionsOpen && !prevVal) {
-					var optionItem = comboBox.icons.item('options');
+					var optionItem = comboBox.icons.item('options_' + comboBoxIconRandomId);
 
 					optionItem.StateInteraction.set('active', true);
 					optionsOverlay.show();


### PR DESCRIPTION
Jon,

http://issues.liferay.com/browse/LPS-29907

Added unique id's to icons because the options icon is referred to by id later in code.

Byran
