### PR TITLE
LPS-30081 - Clicking the gear icon when adding a page, does nothing on the first click

### DIFF
--- a/portal-web/docroot/html/js/liferay/navigation.js
+++ b/portal-web/docroot/html/js/liferay/navigation.js
@@ -424,7 +424,7 @@ AUI.add(
 
 								var action = 'show';
 
-								if (toolItem.StateInteraction.get('active')) {
+								if (!toolItem.StateInteraction.get('active')) {
 									action = 'hide';
 								}
 


### PR DESCRIPTION
Jon,

http://issues.liferay.com/browse/LPS-30081

Because, it seams, the handler function is fired after 'active' is toggled, I negated the conditional for the overlay 'hide' action.

Byran
