### PR TITLE
LPS-28182 Alerts Portlet Does Not Display Border When Show Border Setting is Flagged

### DIFF
--- a/portal-web/docroot/WEB-INF/liferay-portlet.xml
+++ b/portal-web/docroot/WEB-INF/liferay-portlet.xml
@@ -747,7 +747,7 @@
 		<portlet-url-class>com.liferay.portal.struts.StrutsActionPortletURL</portlet-url-class>
 		<preferences-company-wide>false</preferences-company-wide>
 		<preferences-owned-by-group>true</preferences-owned-by-group>
-		<use-default-template>false</use-default-template>
+		<use-default-template>true</use-default-template>
 		<instanceable>false</instanceable>
 		<private-request-attributes>false</private-request-attributes>
 		<private-session-attributes>false</private-session-attributes>


### PR DESCRIPTION
Changed the use-default-template spec in the Alerts portlet to true in liferay-portlet.xml file
