### PR TITLE
LPS-35900

### DIFF
--- a/portal-web/docroot/html/js/liferay/language.js
+++ b/portal-web/docroot/html/js/liferay/language.js
@@ -1,43 +1,58 @@
 ;(function(A, Liferay) {
-	A.use('io-base', function() {
-		Liferay.Language = {
-			get: function(key, extraParams) {
-				var instance = this;
+	A.use(
+		'cache',
+		'iobase',
+		function() {
+			Liferay.Language = {
+				get: function(key, extraParams) {
+					var instance = this;
 
-				var url = themeDisplay.getPathContext() + '/language/' + themeDisplay.getLanguageId() + '/' + key + '/';
+					var url = themeDisplay.getPathContext() + '/language/' + themeDisplay.getLanguageId() + '/' + key + '/';
 
-				if (extraParams) {
-					if (typeof extraParams == 'string') {
-						url += extraParams;
-					}
-					else if (Liferay.Util.isArray(extraParams)) {
-						url += extraParams.join('/');
-					}
-				}
-
-				var value = instance._cache[url];
-
-				if (!value) {
-					A.io(
-						url,
-						{
-							on: {
-								complete: function(i, o) {
-									value = o.responseText;
-								}
-							},
-							sync: true,
-							type: 'GET'
+					if (extraParams) {
+						if (typeof extraParams == 'string') {
+							url += extraParams;
 						}
-					);
+						else if (Liferay.Util.isArray(extraParams)) {
+							url += extraParams.join('/');
+						}
+					}
 
-					instance._cache[url] = value;
-				}
+					var value = instance._cache.retrieve(url);
 
-				return value;
-			},
+					if (!value) {
+						A.io(
+							url,
+							{
+								on: {
+									complete: function(i, o) {
+										value = o.responseText;
+									}
+								},
+								sync: true,
+								type: 'GET'
+							}
+						);
 
-			_cache: {}
-		};
-	}
+						instance._cache.add(url, value);
+					}
+
+					return value;
+				},
+
+				_cache: new A.Cache(
+					{
+						max: 250,
+						on: {
+							complete: function(i, o) {
+								value = o.responseText;
+							}
+						},
+						sync: true,
+						type: 'GET'
+					}
+				)
+			};
+		}
+	);
 })(AUI(), Liferay);


### PR DESCRIPTION
Hey Jon, you can run this script to print off this script to request about 500 language keys...and then optionally once more after cache has been loaded AUI().Get.script('http://git.io/YdQyog'); . In general, it seemed to print slower than simple using a basic cache object before. Running that script wont work in IE. you have to run it manually here http://git.io/wMDUSw. I'm also kind of stuck on the wrapper of this peice. I think we will eventually need to wrap it in an AUI.add( ... )  but for now I'm just doing an A.use inside the closure -- a pattern I don't see anywhere else meaning its probably not good. Anyways, lets discuss this when you get a chance.
