### PR TITLE
LPS-36294

### DIFF
--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -3687,6 +3687,7 @@ notify=Notify
 now=Now
 ntlm-enabled=NTLM Enabled
 ntlm=NTLM
+num-of-articles=# of Articles
 num-of-categories=# of Categories
 num-of-documents=# of Documents
 num-of-downloads=# of Downloads


### PR DESCRIPTION
This was just missing a language key. I went pretty far back in the history of Language.properties but failed to find if this key ever existed.
