### PR TITLE
LPS-38219

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/css/main.css
+++ b/portal-web/docroot/html/portlet/document_library/css/main.css
@@ -414,7 +414,10 @@
 		}
 
 		.entry-title {
+			overflow: hidden;
 			position: relative;
+			text-overflow: ellipsis;
+			white-space: nowrap;
 		}
 
 		.entry-title-text {


### PR DESCRIPTION
Hey Jon. Adam had originally proposed a fix that would simply hide overflow and set a max-height for a file name. However, since we follow the pattern in other places in the portal to truncate a long name with ellipsis, we should apply that pattern here too. DL filenames have been getting away with multiple lines for too long. I feel this looks more consistent and clean.
