### PR TITLE
LPS-39312 Input to select all elements in search container doesn't toggl...

### DIFF
--- a/portal-web/docroot/html/js/liferay/util.js
+++ b/portal-web/docroot/html/js/liferay/util.js
@@ -2017,7 +2017,7 @@
 
 			if (searchContainer) {
 				searchContainer.delegate(
-					'change',
+					'click',
 					function() {
 						Liferay.Util.toggleDisabled(buttonId, !Liferay.Util.listCheckedExcept(form, ignoreFieldName));
 					},


### PR DESCRIPTION
...e properly

Hey Jon,

The reason I changed this delegate from the change event to the click event is that Chrome actually fires the change event before the click event when clicking on checkboxes, while all the other major browsers do the opposite. This way the toggleDisabled() function doesn't fire until after the checkAllBox has updated the value of the checkboxes in the search container. I tested it in all the major browsers and it works across the board now.
