### PR TITLE
LPS-39375 - Shutdown's form validation allows improper chars and wrong error message

### DIFF
--- a/portal-web/docroot/html/common/themes/top_messages.jsp
+++ b/portal-web/docroot/html/common/themes/top_messages.jsp
@@ -19,7 +19,7 @@
 <c:if test="<%= ShutdownUtil.isInProcess() %>">
 	<div class="alert alert-block" id="lfrShutdownMessage">
 		<span class="notice-label"><liferay-ui:message key="maintenance-alert" /></span> <span class="notice-date"><%= FastDateFormatFactoryUtil.getTime(locale).format(Time.getDate(CalendarFactoryUtil.getCalendar(timeZone))) %> <%= timeZone.getDisplayName(false, TimeZone.SHORT, locale) %></span>
-		<span class="notice-message"><%= LanguageUtil.format(pageContext, "the-portal-will-shutdown-for-maintenance-in-x-minutes", String.valueOf(ShutdownUtil.getInProcess() / Time.MINUTE), false) %></span>
+		<span class="notice-message"><%= LanguageUtil.format(pageContext, "the-portal-will-shutdown-for-maintenance-in-x-minutes", String.valueOf((ShutdownUtil.getInProcess() / Time.MINUTE) + 1), false) %></span>
 
 		<c:if test="<%= Validator.isNotNull(ShutdownUtil.getMessage()) %>">
 			<span class="custom-shutdown-message"><%= HtmlUtil.escape(ShutdownUtil.getMessage()) %></span>

--- a/portal-web/docroot/html/js/liferay/form.js
+++ b/portal-web/docroot/html/js/liferay/form.js
@@ -150,7 +150,7 @@ AUI.add(
 					_processFieldRule: function(rules, strings, rule) {
 						var instance = this;
 
-						var value = true;
+						var value = 0;
 
 						var fieldName = rule.fieldName;
 						var validatorName = rule.validatorName;

--- a/portal-web/docroot/html/portlet/admin/server.jspf
+++ b/portal-web/docroot/html/portlet/admin/server.jspf
@@ -818,7 +818,8 @@ serverURL.setParameter("tabs3", tabs3);
 						<c:otherwise>
 							<aui:fieldset>
 								<aui:input label="number-of-minutes" name="minutes" size="3" type="text">
-									<aui:validator name="min">0</aui:validator>
+									<aui:validator name="min">1</aui:validator>
+									<aui:validator name="number" />
 									<aui:validator name="required" />
 								</aui:input>
 


### PR DESCRIPTION
http://issues.liferay.com/browse/LPS-39375
