### PR TITLE
LPS-39369 Page titles overflow from their container when they are long 

### DIFF
--- a/portal-web/docroot/html/css/portal/tree.css
+++ b/portal-web/docroot/html/css/portal/tree.css
@@ -11,6 +11,17 @@
 			padding-left: 0;
 		}
 
+		&.tree-node .tree-node-content {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			width: 100%;
+
+			.tree-label {
+				display: inline;
+			}
+		}
+
 		&.tree-item {
 			padding-left: 5px;
 

--- a/portal-web/docroot/html/css/taglib/header.css
+++ b/portal-web/docroot/html/css/taglib/header.css
@@ -4,6 +4,14 @@
 
 	.header-title {
 		margin: 0.1em;
+
+		.lfr-nav-item {
+			display: inline-block;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			width: 100%;
+		}
 	}
 
 	.header-back-to a {

--- a/portal-web/docroot/html/themes/classic/_diffs/css/custom.css
+++ b/portal-web/docroot/html/themes/classic/_diffs/css/custom.css
@@ -64,6 +64,16 @@ $dockbarOpenGradientStart: #0EA6F9;
 
 	.site-navigation {
 		margin-bottom: 6px;
+
+		.lfr-nav-item {
+			span, a {
+				display: inline-block;
+				max-width: 300px;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+		}
 	}
 
 	/* ---------- Dockbar ---------- */

--- a/portal-web/docroot/html/themes/classic/_diffs/css/custom_common.css
+++ b/portal-web/docroot/html/themes/classic/_diffs/css/custom_common.css
@@ -392,6 +392,11 @@
 		padding: 3px 15px 2px;
 
 		li {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			width: 100%;
+
 			span.divider {
 				color: #999;
 				font-weight: bold;


### PR DESCRIPTION
Hey Jon, I updated this branch to fix the screenshots you showed me. It seems like the add panel no longer suffered from this symptom. I corrected the problem in the Navigation Tree (Site Pages) and also fixed the problem with child pages in a nav taglib. Let me know if you have any questions
