### PR TITLE
LPS-40026 - Liferay-ui:input-time displays time in AM even when it is set as PM

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_time/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_time/page.jsp
@@ -55,6 +55,10 @@ if (!DateUtil.isFormatAmPm(locale)) {
 	amPmValue = Calendar.AM;
 }
 
+if (amPmValue > 0) {
+	calendar.set(Calendar.AM_PM, Calendar.PM);
+}
+
 Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(simpleDateFormatPattern, locale);
 %>
 
@@ -97,9 +101,6 @@ Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(simpleDateFormatPa
 							<c:if test="<%= DateUtil.isFormatAmPm(locale) %>">
 								if (hours > 11) {
 									amPm = 1;
-								}
-
-								if (hours > 12) {
 									hours -= 12;
 								}
 							</c:if>


### PR DESCRIPTION
http://issues.liferay.com/browse/LPS-40026
