### PR TITLE
LPS-40433 Malformed start tag warning in IE 10. 

### DIFF
--- a/util-taglib/src/com/liferay/taglib/aui/NavBarSearchTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/NavBarSearchTag.java
@@ -43,7 +43,7 @@ public class NavBarSearchTag extends BaseNavBarSearchTag {
 
 			sb.append("<a class=\"btn btn-navbar\" id=\"");
 			sb.append(_getNamespacedId());
-			sb.append("NavbarBtn\"");
+			sb.append("NavbarBtn\" ");
 			sb.append("data-navId=\"");
 			sb.append(_getNamespacedId());
 			sb.append("\">");


### PR DESCRIPTION
hey @jonmak08, I can confirm that this is the only place in portal where we are using sb.append and two markup elements are mashed together via this regex search: http://cl.ly/image/082U2L1l1e1X
