### PR TITLE
LPS-40164 - Roles: Define Permissions page menus don't work in IE 9

### DIFF
--- a/portal-web/docroot/html/portlet/roles_admin/edit_role_permissions.jsp
+++ b/portal-web/docroot/html/portlet/roles_admin/edit_role_permissions.jsp
@@ -374,7 +374,10 @@ portletURL.setParameter("roleId", String.valueOf(role.getRoleId()));
 					animated: true,
 					container: <portlet:namespace />permissionNavigationDataContainer,
 					content: '.permission-navigation-item-content',
-					header: '.permission-navigation-item-header'
+					header: '.permission-navigation-item-header',
+					transition: {
+						duration: 0.3
+					}
 				}
 			);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-40164
