### PR TITLE
LPS-40962 Portlet Look and Feel - Border Styles font size text fields an...

### DIFF
--- a/portal-web/docroot/html/css/portal/forms.css
+++ b/portal-web/docroot/html/css/portal/forms.css
@@ -3,7 +3,6 @@
 
 .control-group-inline {
 	display: inline-block;
-	vertical-align: middle;
 }
 
 .button-holder {


### PR DESCRIPTION
...d unit drop downs misaligned

Hey @jonmak08

vertical-align: middle was added to this class in Nate's SF of https://issues.liferay.com/browse/LPS-35357. It's no longer needed in that situation, and I checked numerous other use cases throughout portal. In most situations it doesn't change anything, but in a number of use cases removing the vertical alignment actually fixes other alignment issues. I haven't seen a single use case where this is needed.
