### PR TITLE
LPS-41170 - Limit tag name size to 75 chars and fix overflow styling

### DIFF
--- a/portal-web/docroot/html/taglib/ui/asset_tags_selector/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/asset_tags_selector/page.jsp
@@ -45,7 +45,14 @@ if (curTagsParam != null) {
 	<input class="lfr-tag-selector-input" id="<%= id %>assetTagNames" size="15" title="<liferay-ui:message key="add-tags" />" type="text" />
 </div>
 
-<aui:script use="liferay-asset-tags-selector">
+<aui:script use="aui-char-counter,liferay-asset-tags-selector">
+	new A.CharCounter(
+		{
+			input: '#<%= id %>assetTagNames',
+			maxLength: 75
+		}
+	);
+
 	new Liferay.AssetTagsSelector(
 		{
 			allowSuggestions: <%= PropsValues.ASSET_TAG_SUGGESTIONS_ENABLED %>,

--- a/portal-web/docroot/html/themes/_styled/css/application.css
+++ b/portal-web/docroot/html/themes/_styled/css/application.css
@@ -108,6 +108,10 @@
 		}
 	}
 
+	.textboxlistentry-content{
+		word-break: break-all;
+	}
+
 	.textboxlistentry-remove {
 		padding: 0 3px 1px;
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-41170
