### PR TITLE
LPS-41268 - IE9 Dockbar cannot be seen on mobile screen widths

### DIFF
--- a/portal-web/docroot/html/themes/classic/_diffs/css/custom.css
+++ b/portal-web/docroot/html/themes/classic/_diffs/css/custom.css
@@ -501,6 +501,8 @@ $dockbarOpenGradientStart: #0EA6F9;
 			}
 
 			> .active > a {
+				background-color: $dockbarGradientStart;
+
 				@include background-image(linear-gradient($dockbarGradientStart 0%, $dockbarGradientStart 47%, $dockbarGradientEnd 100%));
 				@include box-shadow(none);
 				@include filter-gradient($dockbarGradientStart, $dockbarGradientEnd, vertical);
@@ -576,6 +578,8 @@ $dockbarOpenGradientStart: #0EA6F9;
 			@include text-shadow(none);
 
 			@include respond-to(phone, tablet) {
+				background-color: $dockbarGradientStart;
+
 				@include background-image(linear-gradient($dockbarGradientStart, $dockbarGradientEnd));
 			}
 
@@ -589,6 +593,8 @@ $dockbarOpenGradientStart: #0EA6F9;
 					}
 
 					> .staging-link.dropdown-toggle {
+						background-color: #0279E1;
+
 						@include background-image(linear-gradient(#0279E1, #0264CC));
 					}
 				}

--- a/portal-web/docroot/html/themes/classic/_diffs/css/custom_common.css
+++ b/portal-web/docroot/html/themes/classic/_diffs/css/custom_common.css
@@ -813,7 +813,9 @@
 	}
 
 	.nav-header {
-		background-image: linear-gradient(#FFF, #F2F2F2);
+		background-color: #FFF;
+
+		@include background-image(linear-gradient(#FFF 0%, #F2F2F2 100%));
 	}
 
 	.portlet-options {

--- a/portal-web/docroot/html/themes/classic/_diffs/css/custom_responsive.css
+++ b/portal-web/docroot/html/themes/classic/_diffs/css/custom_responsive.css
@@ -180,7 +180,7 @@
 								margin: 5px 0;
 								padding: 6px 15px;
 
-								&:hover {
+								&:focus, &:hover {
 									background-color: #5BBAE8;
 								}
 							}

--- a/portal-web/docroot/html/themes/control_panel/_diffs/css/custom.css
+++ b/portal-web/docroot/html/themes/control_panel/_diffs/css/custom.css
@@ -833,6 +833,8 @@ $dockbarOpenGradientStart: #0EA6F9;
 
 	.panel-page-menu .portlet-borderless-container {
 		&:after {
+				background-color: #D1D1D1;
+
 				@include background-image(linear-gradient(#FFF, #D1D1D1));
 
 				content: '';
@@ -876,11 +878,15 @@ $dockbarOpenGradientStart: #0EA6F9;
 
 	.dockbar {
 		.navbar-inner {
+			background-color: $dockbarGradientStart;
+
 			@include background-image(linear-gradient(top, $dockbarGradientStart, $dockbarGradientEnd));
 			@include filter-gradient($dockbarGradientStart, $dockbarGradientEnd, vertical);
 
 			ul.nav-account-controls {
 				li.open > .dropdown-toggle {
+					background-color: $dockbarGradientStart;
+
 					@include background-image(linear-gradient(top, $dockbarOpenGradientStart, $dockbarOpenGradientEnd));
 					@include box-shadow(none);
 					@include filter-gradient($dockbarOpenGradientStart, $dockbarOpenGradientEnd, vertical);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-41268

Hey Jon,

I fixed the dockbar being white on mobile screen widths in IE9. Nate also asked me to add background-color in places where background-image didn't have a fall back. In custom_common.css .nav-account-controls li ul li a:hover i {}, I didn't add a fallback because in the dockbar dropdowns it makes the circle around the caret disappear on hover.

Patrick
