### PR TITLE
LPS-41576 In Site Admin > Documents and Media, a scroll bar appears in t...

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/css/main.css
+++ b/portal-web/docroot/html/portlet/document_library/css/main.css
@@ -114,10 +114,6 @@
 		}
 	}
 
-	.document-container {
-		overflow: auto;
-	}
-
 	.document-container, .document-entries-pagination {
 		clear: both;
 	}


### PR DESCRIPTION
...he descriptive view that has no functional affect

Hey @jonmak08

This styling was originally added for LPS-20047 because the table in the list view was flowing out of the portlet boundaries. That issue has since been resolved for all search containers, so it's no longer needed.
