### PR TITLE
LPS-42626 long first and last name will extend out of range in Sign In portlet and user profile 

### DIFF
--- a/portal-web/docroot/html/portlet/login/css/main.css
+++ b/portal-web/docroot/html/portlet/login/css/main.css
@@ -32,4 +32,8 @@
 		border-top: 1px solid #BFBFBF;
 		padding: 10px;
 	}
+
+	.signed-in-as {
+		word-wrap: break-word;
+	}
 }

--- a/portal-web/docroot/html/portlet/login/login.jsp
+++ b/portal-web/docroot/html/portlet/login/login.jsp
@@ -26,12 +26,12 @@
 			String myAccountURL = String.valueOf(themeDisplay.getURLMyAccount());
 
 			if (PropsValues.DOCKBAR_ADMINISTRATIVE_LINKS_SHOW_IN_POP_UP) {
-				signedInAs = "<a href=\"javascript:Liferay.Util.openWindow({dialog: {destroyOnHide: true}, title: '" + LanguageUtil.get(pageContext, "my-account") + "', uri: '" + HtmlUtil.escape(myAccountURL) + "'});\">" + signedInAs + "</a>";
+				signedInAs = "<a class=\"signed-in-as\" href=\"javascript:Liferay.Util.openWindow({dialog: {destroyOnHide: true}, title: '" + LanguageUtil.get(pageContext, "my-account") + "', uri: '" + HtmlUtil.escape(myAccountURL) + "'});\">" + signedInAs + "</a>";
 			}
 			else {
 				myAccountURL = HttpUtil.setParameter(myAccountURL, "controlPanelCategory", PortletCategoryKeys.MY);
 
-				signedInAs = "<a href=\"" + HtmlUtil.escape(myAccountURL) + "\">" + signedInAs + "</a>";
+				signedInAs = "<a class=\"signed-in-as\" href=\"" + HtmlUtil.escape(myAccountURL) + "\">" + signedInAs + "</a>";
 			}
 		}
 		%>

--- a/portal-web/docroot/html/portlet/users_admin/css/main.css
+++ b/portal-web/docroot/html/portlet/users_admin/css/main.css
@@ -178,6 +178,10 @@
 				margin-right: 5px;
 				width: 35px;
 			}
+
+			.user-name {
+				word-wrap: break-word;
+			}
 		}
 	}
 


### PR DESCRIPTION
Hey @jonmak08. I found another place to apply a fix to the reported bug. When you click on the User name it will load My Account. That name in the top right also needed word-wrap: break-word. Let me know if you think this should be in a seperate commit or LPS bug fix.
