### PR TITLE
LPS-42412 On a small mobile device (320 pixels), the comment box is cut ...

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/css/main.css
+++ b/portal-web/docroot/html/portlet/document_library/css/main.css
@@ -501,11 +501,6 @@
 		}
 	}
 
-	.taglib-discussion {
-		width: 90%;
-		margin: 0 auto;
-	}
-
 	.taglib-ratings.stars {
 		border: 1px solid transparent;
 		display: inline-block;


### PR DESCRIPTION
...off on a DM document

Hey @jonmak

This is the only place in portal where I found this exact issue with a textarea, caused by the unusual amount of margin added to the taglib. The code I deleted is from LPS-15574, which was a general restyling of Document Library.
