### PR TITLE
Revert "LPS-42794 - Source formatting"

### DIFF
--- a/portal-web/docroot/html/js/liferay/translation_manager.js
+++ b/portal-web/docroot/html/js/liferay/translation_manager.js
@@ -55,7 +55,7 @@ AUI.add(
 
 		var TPL_LOCALE_IMAGE = '<img src="' + themeDisplay.getPathThemeImages() + '/language/{locale}.png" />';
 
-		var TPL_AVAILABLE_TRANSLATION_LINK = '<span class="' + CSS_TRANSLATION + ' {cssClass}" locale="{locale}">' + TPL_LOCALE_IMAGE + '{displayName} <a class="' + CSS_DELETE_TRANSLATION + ' icon icon-remove" href="javascript:;" /></span>';
+		var TPL_AVAILABLE_TRANSLATION_LINK = '<span class="' + CSS_TRANSLATION + ' {cssClass}" locale="{locale}">' + TPL_LOCALE_IMAGE + '{displayName} <a class="' + CSS_DELETE_TRANSLATION + ' icon icon-remove" href="javascript:;"></a></span>';
 
 		var TPL_AVAILABLE_TRANSLATIONS_LINKS_NODE = '<span class="' + CSS_AVAILABLE_TRANSLATIONS_LINKS + '"></span>';
 


### PR DESCRIPTION
This reverts commit ea9bb7dad23d48b03abe3c9a65e869f54a661419.

Hey @jonmak

I reverted your source formatting on my original commit because it caused issues when multiple translations were added. See screen shot.

![screen shot 2013-12-17 at 3 58 27 pm](https://f.cloud.github.com/assets/2466445/1769701/9298ea70-6778-11e3-845d-78193e8da9bf.png)
