### PR TITLE
LPS-42998 Master only - In the mobile view or on a mobile device (768 - ...

### DIFF
--- a/portal-web/docroot/html/themes/_styled/css/dockbar.css
+++ b/portal-web/docroot/html/themes/_styled/css/dockbar.css
@@ -829,6 +829,10 @@ $editLayoutPanelWidth: 460px;
 			position: static;
 			width: auto;
 
+			@include respond-to(tablet) {
+				margin: 0;
+			}
+
 			&.lfr-add-panel .add-content-menu .lfr-add-page-toolbar, &.lfr-edit-layout-panel .taglib-form-navigator .button-holder {
 				margin-top: 0;
 				position: static;
@@ -860,9 +864,13 @@ $editLayoutPanelWidth: 460px;
 		padding-left: $editLayoutPanelWidth;
 	}
 
-	@include respond-to(phone) {
-		.lfr-has-add-content, .lfr-has-device-preview, .lfr-has-edit-layout {
+	.lfr-has-add-content, .lfr-has-device-preview, .lfr-has-edit-layout {
+		@include respond-to(phone) {
 			padding-left: 20px;
+		}
+
+		@include respond-to(tablet) {
+			padding-left: 0;
 		}
 	}
 


### PR DESCRIPTION
...979 pixels), the Add/Edit sidebar leaves excess white space on the left

Hey @jonmak

I decided to stretch the admin panel to the full width in the tablet view just as it is in the phone view. If we make the tablet view resemble the desktop view with the panel on the left, it'll look like this.

![screen shot 2013-12-19 at 9 40 15 am](https://f.cloud.github.com/assets/2466445/1784650/3f27d7f2-68d6-11e3-91b0-45fa5586aa3d.png)

Which IMO is too squished. Also this way the admin panel matches the behavior of the dockbar (they both stretch to 100% width at the same screen width).
