### PR TITLE
LPS-41929 - On mobile, make permissions table easier to read

### DIFF
--- a/portal-web/docroot/html/css/portal/generic_portlet.css
+++ b/portal-web/docroot/html/css/portal/generic_portlet.css
@@ -1,4 +1,5 @@
 @import "compass";
+@import "mixins";
 
 .breadcrumbs {
 	margin-bottom: 10px;
@@ -45,8 +46,6 @@
 
 	tr td, tr th {
 		padding: 0 5px;
-
-		@include word-break(break-all);
 
 		&:first-child, &.first-child {
 			padding-left: 0;
@@ -103,3 +102,103 @@
 		zoom: 1;
 	}
 }
+
+@include respond-to(phone, tablet) {
+	.lfr-table {
+		display: block;
+		position: relative;
+		width: 100%;
+
+		&:after {
+			content: " ";
+			clear: both;
+			display: block;
+			font-size: 0;
+			height: 0;
+			visibility: hidden;
+		}
+
+		thead {
+			display: block;
+			float: left;
+			margin-right: 10px;
+
+			&:after {
+				content: " ";
+				clear: both;
+				display: block;
+				font-size: 0;
+				height: 0;
+				visibility: hidden;
+			}
+
+			th {
+				display: block;
+				margin-bottom: 20px;
+				text-align: right !important;
+			}
+		}
+
+		tbody {
+			display: block;
+			overflow-x: auto;
+			position: relative;
+			white-space: nowrap;
+			width: auto;
+
+			tr {
+				display: inline-block;
+				vertical-align: top;
+
+				td {
+					display: block;
+					margin-bottom: 20px;
+				}
+			}
+		}
+
+		label.hidden-label {
+			display: block;
+			overflow: hidden;
+			width: 10px;
+		}
+	}
+
+
+	.ie9, .ie8, .ie7, .ie6 {
+		.control-group {
+			overflow: auto;
+		}
+
+		.lfr-table {
+			display: table;
+			position: static;
+			width: auto;
+
+			thead {
+				display: table-header-group;
+				float: none;
+				margin-right: auto;
+
+				th {
+					display: table-cell;
+					margin-bottom: auto;
+				}
+			}
+
+			tbody {
+				display: table-row-group;
+				overflow-x: auto;
+				position: static;
+
+				tr {
+					display: table-row;
+
+					td {
+						display: table-cell;
+						margin-bottom: auto;
+					}
+				}
+			}
+		}
+	}

--- a/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
@@ -127,25 +127,27 @@ String modelName = (String)request.getAttribute("liferay-ui:input-permissions:mo
 		</p>
 
 		<table class="lfr-table <%= inputPermissionsShowOptions ? "" : "hide" %>" id="<%= uniqueNamespace %>inputPermissionsTable">
-		<tr>
-			<th>
-				<liferay-ui:message key="roles" />
-			</th>
-
-			<%
-			for (int i = 0; i < supportedActions.size(); i++) {
-				String action = (String)supportedActions.get(i);
-			%>
-
-				<th <%= (action.equals(ActionKeys.VIEW)) ? "class=\"hide\"" : "" %> style="text-align: center;">
-					<%= ResourceActionsUtil.getAction(pageContext, action) %>
+		<thead>
+			<tr>
+				<th>
+					<liferay-ui:message key="roles" />
 				</th>
 
-			<%
-			}
-			%>
+				<%
+				for (int i = 0; i < supportedActions.size(); i++) {
+					String action = (String)supportedActions.get(i);
+				%>
 
-		</tr>
+					<th <%= (action.equals(ActionKeys.VIEW)) ? "class=\"hide\"" : "" %> style="text-align: center;">
+						<%= ResourceActionsUtil.getAction(pageContext, action) %>
+					</th>
+
+				<%
+				}
+				%>
+
+			</tr>
+		</thead>
 
 		<%
 		for (String roleName : roleNames) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-41929

Hey @jonmak08, I looked at the list of responsive tables and thought a pure css approach would be lighter than implementing a javascript plugin. The problem I ran into with a pure css approach is that the design patterns don't work in ie9 and below. In ie9 and below, I used overflow on the container method so the user can still scroll sideways to view the table.

I removed @include word-break(break-all) from line 49 because it looks like it was a fix for ee-6.1.x. Nate changed the mark up for Recent Downloads portlet in 6.2.

https://issues.liferay.com/browse/LPS-41940
Fix for 6.2: https://github.com/liferay/liferay-portal/commit/421d7fb18a2232e1da689d3d09e19c29e0ef6e30
Fix for ee-6.1.x: https://github.com/liferay/liferay-portal/commit/003e723a3e6cebcef44566deb674d438c08f3ce9
