### PR TITLE
LPS-43366 The content of menu can not display completely on mobile devic...

### DIFF
--- a/portal-web/docroot/html/themes/_styled/css/dockbar.css
+++ b/portal-web/docroot/html/themes/_styled/css/dockbar.css
@@ -1107,7 +1107,7 @@ $editLayoutPanelWidth: 460px;
 
 	/* LPS-42547 */
 
-	.dockbar-split .dockbar .nav-collapse {
+	.dockbar .nav-collapse {
 		-webkit-transform: none;
 	}
 }


### PR DESCRIPTION
Hey @jonmak08

This same issue was fixed for classic theme (LPS-42547), but it was prepended with .dockbar-split which isn't used in the control panel theme. That's why I removed it.
