### PR TITLE
LPS-43251 resize browser in preview mode will shift the background to th...

### DIFF
--- a/portal-web/docroot/html/js/liferay/dockbar_device_preview.js
+++ b/portal-web/docroot/html/js/liferay/dockbar_device_preview.js
@@ -132,6 +132,17 @@ AUI.add(
 							instance._devicePreviewContainer.delegate(STR_CLICK, instance._onDeviceClick, SELECTOR_DEVICE_ITEM, instance)
 						);
 
+						var resizeHandle = A.getWin().on(
+							'resize',
+							function(event) {
+								if (Liferay.Util.isTablet()) {
+									instance._closePanel();
+
+									resizeHandle.detach();
+								}
+							}
+						);
+
 						var inputWidth = instance.get(STR_INPUT_WIDTH);
 
 						if (inputWidth) {


### PR DESCRIPTION
Hey @jonmak08

The reason why I configured the preview panel to close once the window is resized to a tablet/phone size, is that the preview panel isn't even an option in the tablet/phone view in the first place. There really isn't a reason to support the preview panel when the browser window is that small.
