### PR TITLE
LPS-42329 On an iPad (horizontal view), the Edit Controls icon only work...

### DIFF
--- a/portal-web/docroot/html/js/liferay/dockbar.js
+++ b/portal-web/docroot/html/js/liferay/dockbar.js
@@ -144,11 +144,16 @@ AUI.add(
 
 						if (panelTrigger) {
 							panelTrigger.on(
-								EVENT_CLICK,
+								'gesturemovestart',
 								function(event) {
-									event.halt();
+									event.currentTarget.once(
+										'gesturemoveend',
+										function(event) {
+											event.halt();
 
-									instance._togglePanel(panelId);
+											instance._togglePanel(panelId);
+										}
+									);
 								}
 							);
 						}
@@ -493,6 +498,6 @@ AUI.add(
 	},
 	'',
 	{
-		requires: ['aui-node', 'aui-overlay-mask-deprecated', 'event-touch']
+		requires: ['aui-node', 'aui-overlay-mask-deprecated', 'event-move', 'event-touch']
 	}
 );

--- a/portal-web/docroot/html/js/liferay/util.js
+++ b/portal-web/docroot/html/js/liferay/util.js
@@ -1935,22 +1935,27 @@
 				docBody.addClass(currentClass);
 
 				trigger.on(
-					EVENT_CLICK,
+					'gesturemovestart',
 					function(event) {
-						if (icon) {
-							icon.toggleClass(iconVisibleClass).toggleClass(iconHiddenClass);
-						}
+						event.currentTarget.once(
+							'gesturemoveend',
+							function(event) {
+								if (icon) {
+									icon.toggleClass(iconVisibleClass).toggleClass(iconHiddenClass);
+								}
 
-						docBody.toggleClass(visibleClass).toggleClass(hiddenClass);
+								docBody.toggleClass(visibleClass).toggleClass(hiddenClass);
 
-						Liferay._editControlsState = (docBody.hasClass(visibleClass) ? 'visible' : 'hidden');
+								Liferay._editControlsState = (docBody.hasClass(visibleClass) ? 'visible' : 'hidden');
 
-						Liferay.Store('liferay_toggle_controls', Liferay._editControlsState);
+								Liferay.Store('liferay_toggle_controls', Liferay._editControlsState);
+							}
+						);
 					}
 				);
 			}
 		},
-		['liferay-store']
+		['event-move', 'liferay-store']
 	);
 
 	Liferay.provide(


### PR DESCRIPTION
...s when the page is scrolled to the top

Hey @jonmak08

All I changed was the event these functions are fired on. Now there are the same as nav_item drop downs with the gesture events. There is a bug in IOS with elements that have fixed positioning and click events.
