### PR TITLE
LPS-41156 On a mobile device, the flags in the Language portlet are too ...

### DIFF
--- a/portal-web/docroot/WEB-INF/liferay-portlet.xml
+++ b/portal-web/docroot/WEB-INF/liferay-portlet.xml
@@ -762,6 +762,7 @@
 		<private-request-attributes>false</private-request-attributes>
 		<private-session-attributes>false</private-session-attributes>
 		<render-weight>50</render-weight>
+		<header-portlet-css>/html/portlet/language/css/main.css</header-portlet-css>
 		<css-class-wrapper>portlet-language</css-class-wrapper>
 		<add-default-resource>true</add-default-resource>
 	</portlet>

--- a/portal-web/docroot/html/portlet/language/css/main.css
+++ b/portal-web/docroot/html/portlet/language/css/main.css
@@ -1,0 +1,20 @@
+@import "compass";
+@import "mixins";
+
+@include respond-to(phone, tablet) {
+	.portlet-language .portlet-body {
+		.current-language, .taglib-icon, .taglib-language-list-text {
+			border: 1px solid #EAEAEA;
+
+			@include border-radius(10px);
+
+			display: inline-block;
+			margin: 2px 0;
+			padding: 6px 10px;
+		}
+
+		img {
+			vertical-align: baseline;
+		}
+	}
+}

--- a/portal-web/docroot/html/taglib/ui/language/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/language/page.jsp
@@ -144,11 +144,17 @@ for (int i = 0; i < locales.length; i++) {
 					</c:choose>
 				</c:when>
 				<c:otherwise>
+
+					<%
+					boolean currentLanguage = languageId.equals(currentLanguageId);
+					%>
+
 					<liferay-ui:icon
+						cssClass='<%= currentLanguage ? "current-language" : "" %>'
 						image='<%= "../language/" + currentLanguageId %>'
 						lang="<%= LocaleUtil.toW3cLanguageId(locales[i]) %>"
 						message="<%= LocaleUtil.getLongDisplayName(locales[i], duplicateLanguages) %>"
-						url="<%= languageId.equals(currentLanguageId) ? null : HttpUtil.setParameter(formAction, namespace + name, currentLanguageId) %>"
+						url="<%= currentLanguage ? null : HttpUtil.setParameter(formAction, namespace + name, currentLanguageId) %>"
 					/>
 				</c:otherwise>
 			</c:choose>


### PR DESCRIPTION
...small

Hey @jonmak08

Nate and I talked about making the icons themselves larger, but because of how the images work when images_fast_load is set to true, that solution would have been a lot more complicated. So we decided for the language portlet to just make the hitarea of the icons larger.

For the localized inputs, we're waiting. It's not in the scope of the ticket, and we are waiting on Eduardo to change the palette module. Make sure to test with images_fast_load set to both true and false. 
