### PR TITLE
styles in control panel theme to fix icon alignment in RTL languages

### DIFF
--- a/portal-web/docroot/html/themes/control_panel/_diffs/css/main_rtl.css
+++ b/portal-web/docroot/html/themes/control_panel/_diffs/css/main_rtl.css
@@ -10,4 +10,9 @@
 			}
 		}
 	}
+
+	.table .table-cell img[align='left'] {
+		float: right;
+		margin: 0 0 0 5px !important;
+	}
 }


### PR DESCRIPTION
I overrode inline styles to achieve the correct alignment.  I wasn't sure if I should do that or remove the inline styles themselves ('align="left"').  But this fix required fewer changes.
