### PR TITLE
moved button holder on web content management screens to below article body

### DIFF
--- a/portal-web/docroot/html/themes/_styled/css/extras.css
+++ b/portal-web/docroot/html/themes/_styled/css/extras.css
@@ -138,6 +138,18 @@
 	.navbar .navbar-search .form-search .search-query {
 		@include border-radius(14px);
 	}
+
+	.portlet-journal {
+		.tabbable-content.taglib-form-navigator {
+			position: relative;
+		}
+
+		ul.form-navigator.well .button-holder {
+			padding-bottom: 20px;
+			position: absolute;
+			top: 100%;
+		}
+	}
 }
 
 .portlet-document-library, .portlet-dynamic-data-mapping {


### PR DESCRIPTION
added responsive styling to move button holder to below the article body in web content add and edit screens as requested in bug LPS-44603
