### PR TITLE
LPS-44677 - On mobile devices, the execution of the responsive theme for nav components is messy, especially with two sets of navs

### DIFF
--- a/portal-web/docroot/html/js/liferay/modules.js
+++ b/portal-web/docroot/html/js/liferay/modules.js
@@ -713,6 +713,12 @@
 							'aui-io-request'
 						]
 					},
+					'liferay-tabs-responsive': {
+						path: 'tabs_responsive.js',
+						requires: [
+							'aui-base'
+						]
+					},
 					'liferay-toggler-interaction': {
 						path: 'toggler_interaction.js',
 						requires: [

--- a/portal-web/docroot/html/js/liferay/tabs_responsive.js
+++ b/portal-web/docroot/html/js/liferay/tabs_responsive.js
@@ -1,0 +1,111 @@
+AUI.add(
+	'liferay-tabs-responsive',
+	function(A) {
+		var NAV_STACKED = 'nav-stacked';
+
+		var RESIZE = 'resize';
+
+		var TabsResponsive = A.Component.create(
+			{
+				ATTRS: {
+					delay: {
+						validator: function(value) {
+							return (A.Lang.isNumber(value) && value > -1);
+						},
+						value: 100
+					},
+					tabsList: {
+						validator: function(value) {
+							return !!A.one(value);
+						},
+						value: ''
+					}
+				},
+				AUGMENTS: [],
+				EXTENDS: A.Base,
+				NAME: 'tabsresponsive',
+				prototype: {
+					initializer: function() {
+						var instance = this;
+
+						instance._tabsStackedHandler();
+
+						instance._bindUI();
+					},
+
+					_bindUI: function() {
+						var instance = this;
+
+						var tabsStackedHandlerFn = A.bind(instance._tabsStackedHandler, instance);
+
+						A.getWin().on(RESIZE, A.debounce(tabsStackedHandlerFn, instance.get('delay')));
+					},
+
+					_calculateAncestorWidth: function() {
+						var instance = this;
+
+						return instance._getAncestor().width();
+					},
+
+					_getAncestor: function() {
+						var instance = this;
+
+						var ancestor = instance._ancestor;
+
+						if (!ancestor) {
+							ancestor = instance.get('tabsList').ancestor();
+
+							instance._ancestor = ancestor;
+						}
+
+						return ancestor;
+					},
+
+					_getTotalTabsWidth: function() {
+						var instance = this;
+
+						var totalTabsWidth = instance._totalTabsWidth;
+
+						if (!totalTabsWidth) {
+							totalTabsWidth = 0;
+
+							instance.get('tabsList').all('> li').each(
+								function(item, index, collection) {
+									if (!item.hasClass('hide')) {
+										totalTabsWidth += item.outerWidth(true);
+									}
+								}
+							);
+
+							var tabsListMarginHorizontal = instance.get('tabsList').getMargin('lr');
+
+							totalTabsWidth += tabsListMarginHorizontal;
+
+							instance._totalTabsWidth = totalTabsWidth;
+						}
+
+						return totalTabsWidth;
+					},
+
+					_tabsStackedHandler: function() {
+						var instance = this;
+
+						var ancestorWidth = instance._calculateAncestorWidth();
+
+						var totalTabsWidth = instance._getTotalTabsWidth();
+
+						var canFit = (ancestorWidth > totalTabsWidth);
+
+						instance.get('tabsList').toggleClass(NAV_STACKED, !canFit);
+					}
+				}
+			}
+		);
+
+		Liferay.TabsResponsive = TabsResponsive;
+	},
+	'',
+	{
+		requires: ['aui-base']
+	}
+);

--- a/portal-web/docroot/html/portal/layout/view/control_panel.jsp
+++ b/portal-web/docroot/html/portal/layout/view/control_panel.jsp
@@ -98,6 +98,15 @@ request.setAttribute("control_panel.jsp-ppid", ppid);
 			<div class="<%= panelCategory %>">
 				<c:if test="<%= showControlPanelMenu %>">
 					<%@ include file="/html/portal/layout/view/control_panel_nav_main.jspf" %>
+
+					<aui:script use="liferay-tabs-responsive">
+						new Liferay.TabsResponsive(
+							{
+								tabsList: A.one('.control-panel-bar-secondary'),
+								delay: 100
+							}
+						);
+					</aui:script>
 				</c:if>
 
 				<div class="<%= panelBodyCssClass %>">

--- a/portal-web/docroot/html/taglib/ui/tabs/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/tabs/start.jsp
@@ -86,7 +86,20 @@ String onClick = GetterUtil.getString((String)request.getAttribute("liferay-ui:t
 // Type
 
 String type = GetterUtil.getString((String)request.getAttribute("liferay-ui:tabs:type"), "tabs");
+
+//Random Namespace
+
+String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_ui_tabs_start");
 %>
+
+<aui:script use="liferay-tabs-responsive">
+	new Liferay.TabsResponsive(
+		{
+			tabsList: A.one('#<%= randomNamespace + "-" + type %>'),
+			delay: 100
+		}
+	);
+</aui:script>
 
 <c:if test="<%= names.length > 0 %>">
 
@@ -105,7 +118,7 @@ String type = GetterUtil.getString((String)request.getAttribute("liferay-ui:tabs
 		<c:otherwise>
 			<input name="<%= namespace %><%= param %>TabsScroll" type="hidden" />
 
-			<ul class="nav nav-<%= type %>">
+			<ul class="nav nav-<%= type %>" id="<%= randomNamespace + "-" + type %>">
 		</c:otherwise>
 	</c:choose>
 


### PR DESCRIPTION
Hi @jonmak08,

With the help of @marclundgren, I put together a liferay module called tabs-responsive.  It is a solution to the issue described in LPS-44677.  Essentially the module determines if there is enough room to display the tabs horizontally, and if not applies the bootstrap class 'nav-stacked'.  There are some issues where I know it can be improved but I'm a little stuck in figuring out how.

First, for each time the module is used, it attaches a new resize event listener on the window.  I know there should be a way to use the same listener for multiple instances of the tabs, but I'm not sure how.  

Secondly, I currently set up the tabs taglib to use the module and am identifying individual 'nav-tabs' elements by using an ID of 'namespace-name[0]-type'.  Using only the namespace, like is done in other taglibs, isn't specific enough because there are places with multiple instances of tabs in the same namespace.  My solution works for now but I know it is probably not the best  approach.

Thanks in advance!
