### PR TITLE
LPS-42287 On a mobile device, it is difficult to scroll through page …

### DIFF
--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -112,7 +112,7 @@ if (layout != null) {
 		</aui:script>
 	</c:if>
 
-	<aui:script use="liferay-navigation">
+	<aui:script use="event-move,liferay-navigation">
 		Liferay.once(
 			'initNavigation',
 			function() {
@@ -159,7 +159,7 @@ if (layout != null) {
 
 		if (navBlock) {
 			navBlock.once(
-				'mousemove',
+				['gesturemovestart', 'mousemove'],
 				function() {
 					Liferay.fire('initNavigation');
 				}

--- a/portal-web/docroot/html/js/liferay/navigation.js
+++ b/portal-web/docroot/html/js/liferay/navigation.js
@@ -167,6 +167,12 @@ AUI.add(
 						}
 					},
 
+					_afterMakeSortable: function(sortable) {
+						var instance = this;
+
+						sortable.delegate.dd.removeInvalid('a');
+					},
+
 					_cancelPage: function(event) {
 						var instance = this;
 
@@ -638,8 +644,6 @@ AUI.add(
 				var instance = this;
 
 				if (instance.get('isSortable')) {
-					var navBlock = instance.get('navBlock');
-
 					var sortable = new A.Sortable(
 						{
 							container: instance._navList,
@@ -672,7 +676,7 @@ AUI.add(
 						}
 					);
 
-					sortable.delegate.dd.removeInvalid('a');
+					instance._afterMakeSortable(sortable);
 				}
 			},
 			['dd-constrain', 'sortable'],

--- a/portal-web/docroot/html/js/liferay/navigation_touch.js
+++ b/portal-web/docroot/html/js/liferay/navigation_touch.js
@@ -1,12 +1,79 @@
 AUI.add(
 	'liferay-navigation-touch',
 	function(A) {
-		var NavigationProto = Liferay.Navigation.prototype;
+		var Util = Liferay.Util;
 
-		NavigationProto.TPL_DELETE_BUTTON = NavigationProto.TPL_DELETE_BUTTON.replace('hide', '');
+		var SELECTOR_DRAG_HANDLE = '.drag-handle';
+
+		var SELECTOR_LFR_NAV_SORTABLE = '.lfr-nav-sortable';
+
+		var STR_HANDLES = 'handles';
+
+		var TPL_DRAG_HANDLE = '<span class="drag-handle"><i class="icon-reorder"></i></span>';
+
+		A.mix(
+			Liferay.Navigation.prototype,
+			{
+				_afterMakeSortable: function(sortable) {
+					var instance = this;
+
+					var navItems = instance.get('navBlock').all(instance._navItemSelector);
+
+					instance._createDragHandles(navItems);
+
+					var sortableDD = instance._sortableDD = sortable.delegate.dd;
+
+					sortableDD.removeInvalid('a');
+
+					sortableDD.plug(A.Plugin.DDConstrained);
+
+					instance._toggleDragConfig(sortableDD);
+
+					A.on('windowresize', A.bind('_onWindowResize', instance));
+				},
+
+				_createDragHandles: function(items) {
+					var instance = this;
+
+					items.each(
+						function(item, index, collection) {
+							item.append(TPL_DRAG_HANDLE);
+						}
+					);
+				},
+
+				_onWindowResize: function() {
+					var instance = this;
+
+					var sortableDD = instance._sortableDD;
+
+					instance._toggleDragConfig(sortableDD);
+				},
+
+				_toggleDragConfig: function(dd) {
+					var instance = this;
+
+					var tablet = Util.isTablet();
+
+					dd.con.set('stickY', tablet);
+
+					var addHandleString = SELECTOR_DRAG_HANDLE;
+					var removeHandleString = SELECTOR_LFR_NAV_SORTABLE;
+
+					if (!tablet) {
+						addHandleString = SELECTOR_LFR_NAV_SORTABLE;
+						removeHandleString = SELECTOR_DRAG_HANDLE;
+					}
+
+					dd.addHandle(addHandleString);
+					dd.removeHandle(removeHandleString);
+				}
+			},
+			true
+		);
 	},
 	'',
 	{
-		requires: ['event-touch', 'liferay-navigation']
+		requires: ['dd-constrain', 'event-resize', 'event-touch', 'liferay-navigation']
 	}
 );

--- a/portal-web/docroot/html/themes/_styled/css/navigation.css
+++ b/portal-web/docroot/html/themes/_styled/css/navigation.css
@@ -42,9 +42,33 @@
 		}
 	}
 
+	.drag-handle {
+		color: #555;
+		cursor: pointer;
+		font-size: 22px;
+
+		@include opacity(0.5);
+
+		padding: 4px 10px;
+		position: absolute;
+		right: 35px;
+
+		@include text-shadow(-1px -1px 2px #000, 1px 1px 2px #FFF);
+
+		top: 6px;
+
+		@include respond-to(desktop) {
+			display: none;
+		}
+	}
+
 	.lfr-nav-updateable.selected a:hover span {
 		cursor: text;
 	}
+}
+
+.controls-hidden .modify-pages .drag-handle {
+	display: none;
 }
 
 .nav {

--- a/portal-web/docroot/html/themes/classic/_diffs/css/custom.css
+++ b/portal-web/docroot/html/themes/classic/_diffs/css/custom.css
@@ -432,6 +432,10 @@ $dockbarOpenGradientStart: #0EA6F9;
 				top: 0;
 			}
 		}
+
+		.drag-handle {
+			color: #1273C7;
+		}
 	}
 
 	/* ---------- Breadcrumbs ---------- */


### PR DESCRIPTION
...igation without dragging the pages

@jonmak08

Make sure to test with a page that has child pages. There are two reasons that the drag handle isn't aligned   to the right. One is that that's where the caret is located for nav items with children. The second is that on some mobile browsers have native actions when dragging near the edge of the screen, for example, if the handles were aligned to the right, in Chrome dragging the nav items would try to switch tabs.
