### PR TITLE
LPS-43572 - Improve the location of some checkboxes in Asset Publisher's configuration page to make the configuration more user-friendly

### DIFF
--- a/portal-web/docroot/html/portlet/asset_publisher/display_settings.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/display_settings.jspf
@@ -102,9 +102,7 @@
 			for (String conversion : conversions) {
 			%>
 
-			<aui:field-wrapper inlineField="<%= true %>" inlineLabel="left" label="<%= StringUtil.toUpperCase(conversion) %>" name='<%= "extensions" + conversion %>'>
-				<input <%= ArrayUtil.contains(assetPublisherDisplayContext.getExtensions(), conversion) ? "checked": "" %> <%= !assetPublisherDisplayContext.isOpenOfficeServerEnabled() ? "disabled" : "" %> id="<portlet:namespace />extensions<%= conversion %>" name="<portlet:namespace />extensions" type="checkbox" value="<%= conversion %>" />
-			</aui:field-wrapper>
+				<aui:input checked="<%= ArrayUtil.contains(assetPublisherDisplayContext.getExtensions(), conversion) %>" disabled="<%= !assetPublisherDisplayContext.isOpenOfficeServerEnabled() %>" id='<%= "extensions" + conversion %>' includeHiddenField="<%= false %>" inlineField="<%= true %>" label="<%= StringUtil.toUpperCase(conversion) %>" name='<%= "extensions" %>' type="checkbox" value="<%= conversion %>" />
 
 			<%
 			}

--- a/portal-web/docroot/html/portlet/journal_content/configuration.jsp
+++ b/portal-web/docroot/html/portlet/journal_content/configuration.jsp
@@ -250,11 +250,7 @@ catch (NoSuchArticleException nsae) {
 			for (String conversion : conversions) {
 			%>
 
-				<label class="checkbox inline">
-					<input <%= ArrayUtil.contains(extensions, conversion) ? "checked": "" %> <%= openOfficeServerEnabled ? "" : "disabled" %> name="<portlet:namespace />extensions" type="checkbox" value="<%= conversion %>" />
-
-					<%= StringUtil.toUpperCase(conversion) %>
-				</label>
+				<aui:input checked="<%= ArrayUtil.contains(extensions, conversion) %>" disabled="<%= !openOfficeServerEnabled %>" id='<%= "extensions" + conversion %>' includeHiddenField="<%= false %>" inlineField="<%= true %>" label="<%= StringUtil.toUpperCase(conversion) %>" name='<%= "extensions" %>' type="checkbox" value="<%= conversion %>" />
 
 			<%
 			}


### PR DESCRIPTION
Hi @jonmak08,

Attached is an update for http://issues.liferay.com/browse/LPS-43572.

I think the issue with the `<aui: input>`'s not saving had to do with the name attribute containing the extension at the end, for example '_86_extensionspdf', and the fact it was using the hidden input field.  I removed the extension from the name and set the includeHiddenField attribute to false.

Please let me know if there are any issues.

Thanks!
