### PR TITLE
LPS-43967 - Iframe remains open after clicking to Add a translation to a Record

### DIFF
--- a/portal-web/docroot/html/portlet/dynamic_data_lists/edit_record.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_lists/edit_record.jsp
@@ -239,9 +239,20 @@ if (translating) {
 		<aui:button-row>
 			<c:choose>
 				<c:when test="<%= translating %>">
-					<aui:button name="saveTranslationButton" onClick='<%= renderResponse.getNamespace() + "setWorkflowAction(false);" %>' type="submit" value="add-translation" />
+					<aui:button name="saveTranslationButton" onClick='<%= renderResponse.getNamespace() + "saveTranslation(event);" %>' type="submit" value="add-translation" />
 
 					<aui:button href="<%= redirect %>" name="cancelButton" type="cancel" />
+
+					<aui:script>
+						function <portlet:namespace />saveTranslation (event) {
+								var window = Liferay.Util.getWindow('<%= languageId %>');
+
+								<portlet:namespace />setWorkflowAction(false);
+
+								window.hide();
+						}
+					</aui:script>
+
 				</c:when>
 				<c:otherwise>
 

--- a/portal-web/docroot/html/taglib/aui/translation_manager/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/translation_manager/page.jsp
@@ -74,6 +74,10 @@
 				</liferay-ui:icon-menu>
 			</span>
 
+			<div class="alert alert-info hide" id="<portlet:namespace />translationsMessage">
+				<liferay-ui:message key="the-changes-in-your-translations-will-be-available-once-the-content-is-published" />
+			</div>
+
 			<c:if test="<%= availableLocales.length > 1 %>">
 				<div class="lfr-translation-manager-available-translations">
 					<label><liferay-ui:message key="available-translations" /></label>
@@ -141,6 +145,13 @@
 							srcNode: '#<%= namespace + id %> .lfr-translation-manager-content'
 						}
 					).render();
+
+					translationManager.on(
+						'addAvailableLocale',
+						function(event) {
+							A.one(<portlet:namespace />translationsMessage).show();
+						}
+					);
 				}
 
 				return translationManager;


### PR DESCRIPTION
Hi @jonmak08,

Attached is an update for https://issues.liferay.com/browse/LPS-43967.

I moved the translations message into the translation manager taglib as we discussed.

Please let me know if there are any issues.

Thanks!
