### PR TITLE
LPS-45321 - When selecting a new scope in Control Panel we should refresh the portlet being displayed

### DIFF
--- a/portal-web/docroot/html/portal/layout/view/control_panel_site_selector.jspf
+++ b/portal-web/docroot/html/portal/layout/view/control_panel_site_selector.jspf
@@ -37,7 +37,17 @@ Group siteGroup = themeDisplay.getSiteGroup();
 
 manageableSiteGroups.remove(siteGroup);
 
-String switchGroupURL = HttpUtil.setParameter(PortalUtil.getCurrentURL(request), "switchGroup", "1");
+String portletId = ParamUtil.getString(request, "p_p_id");
+
+if (Validator.isNull(portletId)) {
+	portletId = layoutTypePortlet.getStateMaxPortletId();
+}
+
+String switchGroupURL = PortalUtil.getCurrentURL(request);
+
+switchGroupURL = HttpUtil.removeParameter(switchGroupURL, PortalUtil.getPortletNamespace(portletId) + "struts_action");
+
+switchGroupURL = HttpUtil.setParameter(switchGroupURL, "switchGroup", "1");
 %>
 
 <c:choose>


### PR DESCRIPTION
Hi @jonmak08,

Attached is an update for https://issues.liferay.com/browse/LPS-45321.

As mentioned in my previous pull (https://github.com/jonmak08/liferay-portal/pull/684), I have updated the fix so that it will work in the Site Administration site selector as well as in the Control Panel site selector.

Please let me know if there are any issues.

Thanks!
