### PR TITLE
LPS-42322 Adding clickoutside logic

### DIFF
--- a/portal-web/docroot/html/js/liferay/navigation_interaction_touch.js
+++ b/portal-web/docroot/html/js/liferay/navigation_interaction_touch.js
@@ -15,23 +15,48 @@ AUI.add(
 
 					var menuOpen = menuNew.hasClass(STR_OPEN);
 
-					if (menuOpen) {
-						Liferay.fire('hideNavigationMenu', mapHover);
-					}
-					else {
+					var handleId = menuNew.attr('id') + 'Handle';
+
+					var handle = Liferay.Data[handleId];
+
+					if (!menuOpen) {
 						Liferay.fire('showNavigationMenu', mapHover);
 
-						if ((menuOld && menuOld.hasClass(STR_OPEN)) && (menuOld != menuNew)) {
-							menuOld.removeClass(STR_OPEN);
-							menuOld.removeClass('hover');
+						var handle = menuNew.on(
+							['clickoutside', 'touchstartoutside'],
+							function() {
+								Liferay.fire(
+									'hideNavigationMenu',
+									{
+										menu: menuNew
+									}
+								);
+
+								Liferay.Data[handleId] = null;
+
+								handle.detach();
+							}
+						);
+					}
+					else {
+						Liferay.fire('hideNavigationMenu', mapHover);
+
+						if (handle) {
+							handle.detach();
+
+							handle = null;
 						}
 					}
+
+					Liferay.Data[handleId] = handle;
 				},
 
 				_initChildMenuHandlers: function(navigation) {
 					var instance = this;
 
 					if (navigation) {
+						A.Event.defineOutside('touchstart');
+
 						navigation.delegate(['click', 'touchstart'], instance._onTouchClick, '> li > a', instance);
 					}
 				},


### PR DESCRIPTION
Hey @jonmak08

QA failed the first fix for this ticket because they wanted the clickoutside behavior to be applied to the navigation dropdowns as opposed to it just being a toggle. You'll notice that the logic added in this commit looks pretty similar to that in menu_toggle.js, but with a few major differences that would make implementing the menuToggle component a pain. Doing it this way will be less destructive, with less chances of regression bugs. Let me know if you have any questions.
