### PR TITLE
LPS-45276 - When assigning organizational roles, the search results only return site roles

### DIFF
--- a/portal-web/docroot/html/portlet/sites_admin/edit_user_roles.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_user_roles.jsp
@@ -41,6 +41,8 @@ int roleType = ParamUtil.getInteger(request, "roleType", RoleConstants.TYPE_SITE
 Organization organization = null;
 
 if (group.isOrganization()) {
+	roleType = RoleConstants.TYPE_ORGANIZATION;
+
 	organization = OrganizationLocalServiceUtil.getOrganization(group.getClassPK());
 }
 


### PR DESCRIPTION
Hi @jonmak08,

Attached is an update for https://issues.liferay.com/browse/LPS-45276.

I cherry picked the fix from 6.1.x.  

Please let me know if there are any issues.

Thanks!
