### PR TITLE
LPS-46356 - The selection in Asset Publisher's dropdown could not be choosed if the Publisher has nested Scope

### DIFF
--- a/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
@@ -14,58 +14,56 @@
  */
 --%>
 
-<aui:nav>
-	<c:choose>
-		<c:when test="<%= addPortletURLs.size() == 1 %>">
+<c:choose>
+	<c:when test="<%= addPortletURLs.size() == 1 %>">
+
+		<%
+		Set<Map.Entry<String, PortletURL>> addPortletURLsSet = addPortletURLs.entrySet();
+
+		Iterator<Map.Entry<String, PortletURL>> iterator = addPortletURLsSet.iterator();
+
+		Map.Entry<String, PortletURL> entry = iterator.next();
+
+		AssetRendererFactory assetRendererFactory = AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(_getClassName(entry.getKey()));
+
+		String message = _getMessage(entry.getKey(), addPortletURLs, locale);
+		%>
+
+		<aui:nav-item
+			href="<%= _getURL(groupId, plid, entry.getValue(), message, defaultAssetPublisher, layout, pageContext, liferayPortletResponse) %>"
+			iconCssClass="<%= assetRendererFactory.getIconCssClass() %>"
+			iconSrc="<%= assetRendererFactory.getIconPath(liferayPortletRequest) %>"
+			label='<%= LanguageUtil.format(pageContext, "add-x", HtmlUtil.escape(message), false) %>'
+		/>
+	</c:when>
+	<c:otherwise>
+		<aui:nav-item
+			dropdown="<%= true %>"
+			iconCssClass="icon-plus"
+			label='<%= LanguageUtil.format(pageContext, (groupIds.length == 1) ? "add-new" : "add-new-in-x", HtmlUtil.escape((GroupLocalServiceUtil.getGroup(groupId)).getDescriptiveName(locale)), false) %>'
+		>
 
 			<%
-			Set<Map.Entry<String, PortletURL>> addPortletURLsSet = addPortletURLs.entrySet();
+			for (Map.Entry<String, PortletURL> entry : addPortletURLs.entrySet()) {
+				AssetRendererFactory assetRendererFactory = AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(_getClassName(entry.getKey()));
 
-			Iterator<Map.Entry<String, PortletURL>> iterator = addPortletURLsSet.iterator();
-
-			Map.Entry<String, PortletURL> entry = iterator.next();
-
-			AssetRendererFactory assetRendererFactory = AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(_getClassName(entry.getKey()));
-
-			String message = _getMessage(entry.getKey(), addPortletURLs, locale);
+				String message = _getMessage(entry.getKey(), addPortletURLs, locale);
 			%>
 
-			<aui:nav-item
-				href="<%= _getURL(groupId, plid, entry.getValue(), message, defaultAssetPublisher, layout, pageContext, liferayPortletResponse) %>"
-				iconCssClass="<%= assetRendererFactory.getIconCssClass() %>"
-				iconSrc="<%= assetRendererFactory.getIconPath(liferayPortletRequest) %>"
-				label='<%= LanguageUtil.format(pageContext, "add-x", HtmlUtil.escape(message), false) %>'
-			/>
-		</c:when>
-		<c:otherwise>
-			<aui:nav-item
-				dropdown="<%= true %>"
-				iconCssClass="icon-plus"
-				label='<%= LanguageUtil.format(pageContext, (groupIds.length == 1) ? "add-new" : "add-new-in-x", HtmlUtil.escape((GroupLocalServiceUtil.getGroup(groupId)).getDescriptiveName(locale)), false) %>'
-			>
+				<aui:nav-item
+					href="<%= _getURL(groupId, plid, entry.getValue(), message, defaultAssetPublisher, layout, pageContext, liferayPortletResponse) %>"
+					iconCssClass="<%= assetRendererFactory.getIconCssClass() %>"
+					iconSrc="<%= assetRendererFactory.getIconPath(liferayPortletRequest) %>"
+					label="<%= HtmlUtil.escape(message) %>"
+				/>
 
-				<%
-				for (Map.Entry<String, PortletURL> entry : addPortletURLs.entrySet()) {
-					AssetRendererFactory assetRendererFactory = AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(_getClassName(entry.getKey()));
+			<%
+			}
+			%>
 
-					String message = _getMessage(entry.getKey(), addPortletURLs, locale);
-				%>
-
-					<aui:nav-item
-						href="<%= _getURL(groupId, plid, entry.getValue(), message, defaultAssetPublisher, layout, pageContext, liferayPortletResponse) %>"
-						iconCssClass="<%= assetRendererFactory.getIconCssClass() %>"
-						iconSrc="<%= assetRendererFactory.getIconPath(liferayPortletRequest) %>"
-						label="<%= HtmlUtil.escape(message) %>"
-					/>
-
-				<%
-				}
-				%>
-
-			</aui:nav-item>
-		</c:otherwise>
-	</c:choose>
-</aui:nav>
+		</aui:nav-item>
+	</c:otherwise>
+</c:choose>
 
 <%!
 private String _getClassName(String className) {

--- a/portal-web/docroot/html/portlet/asset_publisher/view.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/view.jsp
@@ -74,31 +74,30 @@ boolean hasAddPortletURLs = false;
 
 <c:if test="<%= assetPublisherDisplayContext.isShowAddContentButton() && (scopeGroup != null) && (!scopeGroup.hasStagingGroup() || scopeGroup.isStagingGroup()) && !portletName.equals(PortletKeys.HIGHEST_RATED_ASSETS) && !portletName.equals(PortletKeys.MOST_VIEWED_ASSETS) && !portletName.equals(PortletKeys.RELATED_ASSETS) %>">
 
-	<%
-	boolean defaultAssetPublisher = AssetUtil.isDefaultAssetPublisher(layout, portletDisplay.getId(), portletResource);
+	<aui:nav-bar>
+		<div class="lfr-meta-actions add-asset-selector">
+			<aui:nav>
 
-	long[] groupIds = assetPublisherDisplayContext.getGroupIds();
+				<%
+				boolean defaultAssetPublisher = AssetUtil.isDefaultAssetPublisher(layout, portletDisplay.getId(), portletResource);
 
-	for (long groupId : groupIds) {
-		Map<String, PortletURL> addPortletURLs = AssetUtil.getAddPortletURLs(liferayPortletRequest, liferayPortletResponse, groupId, assetPublisherDisplayContext.getClassNameIds(), assetPublisherDisplayContext.getClassTypeIds(), assetPublisherDisplayContext.getAllAssetCategoryIds(), assetPublisherDisplayContext.getAllAssetTagNames(), null);
+				long[] groupIds = assetPublisherDisplayContext.getGroupIds();
 
-		if ((addPortletURLs != null) && !addPortletURLs.isEmpty()) {
-			hasAddPortletURLs = true;
-		}
-	%>
+				for (long groupId : groupIds) {
+					Map<String, PortletURL> addPortletURLs = AssetUtil.getAddPortletURLs(liferayPortletRequest, liferayPortletResponse, groupId, assetPublisherDisplayContext.getClassNameIds(), assetPublisherDisplayContext.getClassTypeIds(), assetPublisherDisplayContext.getAllAssetCategoryIds(), assetPublisherDisplayContext.getAllAssetTagNames(), null);
 
-		<c:if test="<%= !addPortletURLs.isEmpty() %>">
-			<aui:nav-bar>
-				<div class="lfr-meta-actions add-asset-selector">
+					if ((addPortletURLs != null) && !addPortletURLs.isEmpty()) {
+						hasAddPortletURLs = true;
+					}
+				%>
 					<%@ include file="/html/portlet/asset_publisher/add_asset.jspf" %>
-				</div>
-			</aui:nav-bar>
-		</c:if>
+				<%
+				}
+				%>
 
-	<%
-	}
-	%>
-
+			</aui:nav>
+		</div>
+	</aui:nav-bar>
 </c:if>
 
 <div class="subscribe-action">


### PR DESCRIPTION
Hi @jonmak08,

Attached is an update for https://issues.liferay.com/browse/LPS-46356.

This issue was arising from multiple nav-bars existing in the Asset Publisher.  I thought the best way to fix it was to just combine the different scope drop downs into a single nav bar. 

Please let me know if there are any issues.

Thanks!
