### PR TITLE
LPS-45193 - Page remains in preview mode when browser is minimized with the background shifted

### DIFF
--- a/portal-web/docroot/html/js/liferay/dockbar_device_preview.js
+++ b/portal-web/docroot/html/js/liferay/dockbar_device_preview.js
@@ -128,11 +128,6 @@ AUI.add(
 
 						var eventHandles = instance._eventHandles;
 
-						eventHandles.push(
-							instance._closePanelButton.on(STR_CLICK, instance._closePanel, instance),
-							instance._devicePreviewContainer.delegate(STR_CLICK, instance._onDeviceClick, SELECTOR_DEVICE_ITEM, instance)
-						);
-
 						var resizeHandle = A.getWin().on(
 							'resize',
 							function(event) {
@@ -142,6 +137,12 @@ AUI.add(
 									resizeHandle.detach();
 								}
 							}
+						);
+
+						eventHandles.push(
+							instance._closePanelButton.on(STR_CLICK, instance._closePanel, instance),
+							instance._devicePreviewContainer.delegate(STR_CLICK, instance._onDeviceClick, SELECTOR_DEVICE_ITEM, instance),
+							resizeHandle
 						);
 
 						var inputWidth = instance.get(STR_INPUT_WIDTH);


### PR DESCRIPTION
Hi @jonmak08,

Attached is an update for https://issues.liferay.com/browse/LPS-45193.

The cause of this one was the handle attached to the window resize event wasn't being detached when the preview was closed.

Please let me know if there are any issues.

Thanks!
