### PR TITLE
LPS-43333 - Flag icon is misaligned.

### DIFF
--- a/portal-web/docroot/html/portlet/message_boards/css/main.css
+++ b/portal-web/docroot/html/portlet/message_boards/css/main.css
@@ -314,7 +314,7 @@
 
 	.taglib-flags {
 		float: left;
-		margin-left: 20px;
+		margin: 10px 0 0 20px;
 	}
 
 	.threads-panel {


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-43333.

Please let me know if there are any issues.

Thanks!
