### PR TITLE
LPS-42815 - Error message style does not wrap around long word without spaces completely in entry preview

### DIFF
--- a/portal-web/docroot/html/themes/classic/_diffs/css/custom_common.css
+++ b/portal-web/docroot/html/themes/classic/_diffs/css/custom_common.css
@@ -31,7 +31,7 @@
 		font-weight: 200;
 	}
 
-	.alert {
+	.alert, .portlet-msg-error {
 		word-wrap: break-word;
 	}
 


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-42815.

I wasn't sure where the best place for this fix would be.  I originally thought at the portlet journal level, because that is the only place it is really needed.  But I decided to put it at the theme level because that is where we have the alert style for word-wrap.

Please let me know if there are any issues.

Thanks!
