### PR TITLE
LPS-46696 - Prevent unintentional portlet dragging on mobile devices

### DIFF
--- a/portal-web/docroot/html/js/liferay/layout.js
+++ b/portal-web/docroot/html/js/liferay/layout.js
@@ -13,6 +13,8 @@ AUI.add(
 
 		var LAYOUT_CONFIG = Liferay.Data.layoutConfig;
 
+		var CSS_TOUCH_DRAG_HANDLE = Liferay.Data.PORTLET_TOUCH_DRAG_HANDLE_SELECTOR || 'portlet-touch-drag-handle';
+
 		var Layout = {
 			EMPTY_COLUMNS: {},
 
@@ -157,6 +159,14 @@ AUI.add(
 				return !!columnNode.one(options.portletBoundary);
 			},
 
+			maybeAddTouchHandle: function(portletBoundary) {
+				if (A.UA.touchEnabled) {
+					var portletTitle = portletBoundary.one('.portlet-title');
+
+					portletTitle.append('<div class="' + CSS_TOUCH_DRAG_HANDLE + '"></div>');
+				}
+			},
+
 			on: function() {
 				var layoutHandler = Layout.getLayoutHandler();
 
@@ -269,6 +279,35 @@ AUI.add(
 					}
 				);
 			},
+
+			updatePortletTouchDragHandles: function(event) {
+				var layoutHandler = Layout.getLayoutHandler();
+				var options = Layout.options;
+
+				var drag = layoutHandler.delegate.dd;
+				var dragNodeTitles = A.all(options.dragNodes + ' .portlet-title');
+
+				var touchHandles = ['.' + CSS_TOUCH_DRAG_HANDLE, '.portlet-borderless-bar .portlet-title-default'];
+
+				dragNodeTitles.append('<div class="' + CSS_TOUCH_DRAG_HANDLE + '"></div>');
+
+				A.Array.each(
+					options.handles,
+					function(handle) {
+						drag.removeHandle(handle);
+					}
+				);
+
+				A.Array.each(
+					touchHandles,
+					function(handle) {
+						drag.addHandle(handle);
+					}
+				);
+
+				Layout.options.handles = touchHandles;
+			},
+
 
 			updatePortletDropZones: function(portletBoundary) {
 				var options = Layout.options;
@@ -393,6 +432,10 @@ AUI.add(
 				Layout.bindDragDropListeners();
 
 				Layout.updateEmptyColumnsInfo();
+
+				if (A.UA.touchEnabled) {
+					Layout.updatePortletTouchDragHandles();
+				}
 
 				Liferay.after('closePortlet', Layout._afterPortletClose);
 				Liferay.on('closePortlet', Layout._onPortletClose);

--- a/portal-web/docroot/html/js/liferay/portlet.js
+++ b/portal-web/docroot/html/js/liferay/portlet.js
@@ -303,6 +303,7 @@
 
 					Layout.syncDraggableClassUI();
 					Layout.updatePortletDropZones(portletBoundary);
+					Layout.maybeAddTouchHandle(portletBoundary);
 				}
 
 				if (onComplete) {

--- a/portal-web/docroot/html/themes/classic/_diffs/css/custom.css
+++ b/portal-web/docroot/html/themes/classic/_diffs/css/custom.css
@@ -1,3 +1,5 @@
+@import "aui/alloy-font-awesome/scss/mixins-alloy";
+@import "aui/alloy-font-awesome/scss/variables";
 @import "compass";
 @import "mixins";
 
@@ -456,6 +458,27 @@ $dockbarOpenGradientStart: #0EA6F9;
 		border-top-width: 0;
 		padding: 12px 10px 10px;
 	}
+
+	&.touch .portlet-draggable .portlet-title {
+		&:before {
+			content: $move;
+
+			@include icon-FontAwesome();
+		}
+
+		.portlet-title-text {
+			padding-left: 5px;
+		}
+
+		.portlet-touch-drag-handle {
+			height: 30px;
+			left: 0;
+			position: absolute;
+			top: 0;
+			width: 25px;
+		}
+	}
+
 
 	.portlet-topper {
 		background: #D3D3D3;


### PR DESCRIPTION
Hi Jon,

Attached is another update for https://issues.liferay.com/browse/LPS-46696.

Based on @natecavanaugh's recommendations in https://github.com/natecavanaugh/liferay-portal/pull/2441, I was able to make several improvements.  The css selectors are much simpler and use the `.portlet-title-text:before` selector for the move icon (using the font-awesome mixin).  But I was unable to use that `:before` selector for the actual drag handle.  So unfortunately layout.js still has to touch the DOM to append an invisible span each portlet's handle :(.

I have also been working on a solution that would only use the `clickPixelThresh` and `clickTimeThresh` drag properties to fix the issue, but those don't seem to work as intended on touch devices.  I will continue to try and figure those out though.

Please let me know if there are any issues.

Thanks!
