### PR TITLE
LPS-42251 - Size 72 title is cut off in Web Content in preview

### DIFF
--- a/portal-web/docroot/html/themes/_styled/css/application.css
+++ b/portal-web/docroot/html/themes/_styled/css/application.css
@@ -612,6 +612,7 @@
 body.html-editor {
 	background: #FFF;
 	color: #000;
+	line-height: 1;
 	padding: 1em;
 }
 


### PR DESCRIPTION
Hi Jon,

Attached is an additional fix for https://issues.liferay.com/browse/LPS-42251.

This commit extends the fix to the content in the editor.

Please let me know if there are any issues.

Thanks!
