### PR TITLE
LPS-48044 Breadcrumb styling is off after Bootstrap 3

### DIFF
--- a/portal-web/docroot/html/portlet/dockbar/view.jsp
+++ b/portal-web/docroot/html/portlet/dockbar/view.jsp
@@ -100,8 +100,6 @@ String toggleControlsState = GetterUtil.getString(SessionClicks.get(request, "li
 						<c:when test="<%= controlPanelCategory.startsWith(PortletCategoryKeys.CURRENT_SITE) %>">
 							<%@ include file="/html/portal/layout/view/control_panel_site_selector.jspf" %>
 
-							<span class="divider">/</span>
-
 							<span class="site-administration-title">
 								<liferay-ui:message key="site-administration" />
 							</span>

--- a/portal-web/docroot/html/themes/classic/_diffs/css/custom_common.css
+++ b/portal-web/docroot/html/themes/classic/_diffs/css/custom_common.css
@@ -567,18 +567,9 @@ $dockbarOpenGradientStart: #0EA6F9;
 				vertical-align: text-bottom;
 			}
 
-			span.divider {
-				color: #999;
-				font-weight: bold;
-			}
-
 			&.last {
 				a {
 					color: #676767;
-				}
-
-				span.divider {
-					display: none;
 				}
 			}
 		}


### PR DESCRIPTION
Hey Jon,

I noticed that the styling is off with the breadcrumbs after bootstrap 3. I don't know if there is any plan to address the difference. I thought I would put in one solution. 
