### PR TITLE
LPS-48058 On iOS devices Sign In iframe can allow zooming out far beyond...

### DIFF
--- a/portal-web/docroot/html/js/liferay/util_window.js
+++ b/portal-web/docroot/html/js/liferay/util_window.js
@@ -37,6 +37,38 @@ AUI.add(
 				NAME: A.Modal.NAME,
 
 				prototype: {
+					_getRegion: function (node) {
+						var instance = this;
+
+						var nodeRegion;
+
+						if (!node) {
+							nodeRegion = instance._getViewportRegion();
+						}
+						else {
+							node = A.one(node);
+
+							if (node) {
+								nodeRegion = node.get('region');
+							}
+						}
+
+						return nodeRegion;
+					},
+
+					_getViewportRegion: function() {
+						var instance = this;
+
+						var viewportRegion = instance._viewportRegion;
+
+						if (!viewportRegion) {
+							viewportRegion = instance._posNode.get('viewportRegion');
+
+							instance._viewportRegion = viewportRegion;
+						}
+
+						return viewportRegion;
+					}
 				}
 			}
 		);
@@ -396,14 +428,18 @@ AUI.add(
 					}
 				},
 
-				_syncWindowsUI: function() {
+				_syncWindowsUI: function(event) {
 					var instance = this;
+
+					var currentTarget = event.currentTarget;
 
 					var modals = instance._map;
 
 					A.each(
 						modals,
 						function(modal) {
+							modal._viewportRegion = currentTarget.get('region');
+
 							if (modal.get('visible')) {
 								instance._setWindowDefaultSizeIfNeeded(modal);
 


### PR DESCRIPTION
... the page

Hey @jonmak

Here is an update for LPS-48058. The issue arises when you position a modal window absolute (which we are doing for iOS devices for good reason). What happens is when you open a dialog window for the second time, it calculates the viewportRegion after the modal is displayed, which throws of the calculated region to be much larger than it's supposed to be.

With these changes it only grabs the viewport region the first time and caches it, so it doesn't have to recalculate the region every time. The reason I did it this way, is because it seems like the theme developer should be able to position a modal absolute without throwing the alignment off, even if we didn't have this iOS workaround in place that uncovered the issue.

Let me know if you have any questions.
