### PR TITLE
LPS-49263

### DIFF
--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -53,6 +53,8 @@
 </aui:script>
 
 <aui:script use="aui-base">
+	var trigger = '';
+
 	Liferay.Util.addInputType();
 
 	Liferay.Portlet.ready(
@@ -62,7 +64,13 @@
 	);
 
 	if (A.UA.mobile) {
-		Liferay.Util.addInputCancel();
+		trigger = 'input[type=password], input[type=search], input.clearable, input.search-query';
+	}
+
+	var addInputCancel = Liferay.Util.addInputCancel(trigger);
+
+	if (addInputCancel) {
+		Liferay.fire('liferayInputCancel:added');
 	}
 </aui:script>
 

--- a/portal-web/docroot/html/js/liferay/util.js
+++ b/portal-web/docroot/html/js/liferay/util.js
@@ -100,19 +100,20 @@
 			};
 		},
 
-		addInputCancel: function() {
+		addInputCancel: function(trigger) {
 			A.use(
 				'aui-button-search-cancel',
 				function(A) {
-					new A.ButtonSearchCancel(
+					Liferay.ButtonSearchCancel = new A.ButtonSearchCancel(
 						{
-							trigger: 'input[type=password], input[type=search], input.clearable, input.search-query'
+							trigger: trigger
 						}
 					);
 				}
 			);
 
 			Util.addInputCancel = function(){};
+			return true;
 		},
 
 		addInputFocus: function() {

--- a/portal-web/docroot/html/portlet/search/css/main.css
+++ b/portal-web/docroot/html/portlet/search/css/main.css
@@ -3,6 +3,22 @@
 		margin: 3px 0 0;
 	}
 
+	.form-group {
+		&.search {
+			width: 50%;
+		}
+
+		@media (max-width: 769px) {
+			&.search, &.select {
+				width: 100%;
+			}
+
+			&.select {
+				margin-bottom: 0;
+			}
+		}
+	}
+
 	.menu-column .search-layout-content {
 		padding-left: 24em;
 

--- a/portal-web/docroot/html/portlet/search/search.jsp
+++ b/portal-web/docroot/html/portlet/search/search.jsp
@@ -50,25 +50,21 @@ request.setAttribute("search.jsp-returnToFullPageURL", portletDisplay.getURLBack
 	<portlet:param name="struts_action" value="/search/search" />
 </liferay-portlet:renderURL>
 
-<aui:form action="<%= searchURL %>" method="get" name="fm" onSubmit="event.preventDefault();">
+<aui:form action="<%= searchURL %>" cssClass="form-inline" method="get" name="fm" onSubmit="event.preventDefault();">
 	<liferay-portlet:renderURLParams varImpl="searchURL" />
 	<aui:input name="<%= SearchContainer.DEFAULT_CUR_PARAM %>" type="hidden" value="<%= ParamUtil.getInteger(request, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_CUR) %>" />
 	<aui:input name="format" type="hidden" value="<%= format %>" />
 
 	<aui:fieldset id="searchContainer">
-		<aui:input autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) %>" inlineField="<%= true %>" label="" name="keywords" size="30" title="search" value="<%= HtmlUtil.escape(keywords) %>" />
-
-		<liferay-ui:icon
-			iconCssClass="icon-search"
-			id="searchButton"
-			url="javascript:;"
-		/>
-
-		<liferay-ui:icon
-			iconCssClass="icon-remove"
-			id="clearSearch"
-			url="javascript:;"
-		/>
+		<div class="form-group search">
+			<div class="form-search">
+				<liferay-ui:input-search
+					title="search"
+					showSearchCancel="true"
+					useNamespace="true"
+				/>
+			</div>
+		</div>
 	</aui:fieldset>
 
 	<div class="lfr-token-list" id="<portlet:namespace />searchTokens">
@@ -124,21 +120,10 @@ request.setAttribute("search.jsp-returnToFullPageURL", portletDisplay.getURLBack
 <aui:script use="aui-base">
 	A.one('#<portlet:namespace />searchContainer').delegate(
 		'click',
-		function(event) {
-			var targetId = event.currentTarget.get('id');
-
-			if (targetId === '<portlet:namespace />searchButton') {
-				<portlet:namespace />search();
-			}
-			else if (targetId === '<portlet:namespace />clearSearch') {
-				<portlet:renderURL copyCurrentRenderParameters="<%= false %>" var="clearSearchURL">
-					<portlet:param name="groupId" value="0" />
-				</portlet:renderURL>
-
-				window.location.href = '<%= clearSearchURL %>';
-			}
+		function() {
+			<portlet:namespace />search();
 		},
-		'a'
+		'button'
 	);
 
 	A.one('#<portlet:namespace />keywords').on(

--- a/portal-web/docroot/html/taglib/ui/input_search/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_search/page.jsp
@@ -24,6 +24,7 @@ String id = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-
 String name = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-search:name"));
 String placeholder = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-search:placeholder"));
 boolean showButton = GetterUtil.getBoolean(request.getAttribute("liferay-ui:input-search:showButton"));
+boolean showSearchCancel = GetterUtil.getBoolean(request.getAttribute("liferay-ui:input-search:showSearchCancel"));
 String title = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-search:title"));
 boolean useNamespace = GetterUtil.getBoolean(request.getAttribute("liferay-ui:input-search:useNamespace"), true);
 
@@ -51,5 +52,26 @@ String value = ParamUtil.getString(request, name);
 <c:if test="<%= autoFocus %>">
 	<aui:script>
 		Liferay.Util.focusFormField('#<%= namespace %><%= id %>');
+	</aui:script>
+</c:if>
+
+<c:if test="<%= showSearchCancel %>">
+	<aui:script use="aui-button-search-cancel">
+		if (!A.UA.mobile) {
+			var updateTriggers = function() {
+				var buttonSearchCancel = Liferay.ButtonSearchCancel;
+
+				if(buttonSearchCancel) {
+					buttonSearchCancel.addTriggers('input#<%= namespace + id %>');
+				}
+			}
+
+			if (Liferay.ButtonSearchCancel) {
+				updateTriggers()
+			}
+			else {
+				Liferay.on('liferayInputCancel:added', updateTriggers, Liferay);
+			}
+		}
 	</aui:script>
 </c:if>

--- a/portal-web/docroot/html/taglib/ui/search/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/search/start.jsp
@@ -42,11 +42,18 @@ portletURL.setWindowState(WindowState.MAXIMIZED);
 pageContext.setAttribute("portletURL", portletURL);
 %>
 
-<form action="<%= HtmlUtil.escapeAttribute(portletURL.toString()) %>" method="get" name="<%= randomNamespace %><%= namespace %>fm" onSubmit="<%= randomNamespace %><%= namespace %>search(); return false;">
+<form action="<%= HtmlUtil.escapeAttribute(portletURL.toString()) %>" class="form-inline" method="get" name="<%= randomNamespace %><%= namespace %>fm" onSubmit="<%= randomNamespace %><%= namespace %>search(); return false;">
 	<liferay-portlet:renderURLParams varImpl="portletURL" />
 
 	<aui:fieldset>
-		<aui:input inlineField="<%= true %>" label="" name='<%= namespace + "keywords" %>' size="30" title="search" type="text" useNamespace="<%= false %>" value="<%= HtmlUtil.escapeAttribute(keywords) %>" />
+		<div class="form-group search">
+			<div class="form-search">
+				<liferay-ui:input-search
+					title="search"
+					useNamespace="true"
+				/>
+			</div>
+		</div>
 
 		<%
 		String taglibOnClick = "Liferay.Util.focusFormField('#" + namespace + "keywords');";
@@ -54,19 +61,13 @@ pageContext.setAttribute("portletURL", portletURL);
 
 		<liferay-ui:quick-access-entry label="skip-to-search" onClick="<%= taglibOnClick %>" />
 
-		<aui:select inlineField="<%= true %>" label="" name='<%= namespace + "groupId" %>' title="scope" useNamespace="<%= false %>">
+		<aui:select inlineField="<%= true %>" label="" name='<%= namespace + "groupId" %>' title="scope" useNamespace="<%= false %>" wrapperCssClass="select">
 			<c:if test="<%= !group.isStagingGroup() %>">
 				<aui:option label="everything" selected="<%= (groupId == 0) %>" value="0" />
 			</c:if>
 
 			<aui:option label='<%= "this-" + (group.isOrganization() ? "organization" : "site") %>' selected="<%= (groupId != 0) %>" value="<%= group.getGroupId() %>" />
 		</aui:select>
-
-		<liferay-ui:icon
-			iconCssClass="icon-search"
-			onClick='<%= randomNamespace + namespace + "search();" %>'
-			url="javascript:;"
-		/>
 	</aui:fieldset>
 
 	<aui:script>

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -2202,6 +2202,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>showSearchCancel</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>title</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/util-taglib/src/com/liferay/taglib/ui/InputSearchTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputSearchTag.java
@@ -54,6 +54,10 @@ public class InputSearchTag extends IncludeTag {
 		_showButton = showButton;
 	}
 
+	public void setShowSearchCancel(boolean showSearchCancel) {
+		_showSearchCancel = showSearchCancel;
+	}
+
 	public void setTitle(String title) {
 		_title = title;
 	}
@@ -73,6 +77,7 @@ public class InputSearchTag extends IncludeTag {
 		_name = null;
 		_placeholder = null;
 		_showButton = true;
+		_showSearchCancel=false;
 		_title = null;
 		_useNamespace = true;
 	}
@@ -126,6 +131,8 @@ public class InputSearchTag extends IncludeTag {
 		request.setAttribute(
 			"liferay-ui:input-search:placeholder", placeholder);
 		request.setAttribute("liferay-ui:input-search:showButton", _showButton);
+		request.setAttribute(
+			"liferay-ui:input-search:showSearchCancel", _showSearchCancel);
 		request.setAttribute("liferay-ui:input-search:title", title);
 		request.setAttribute(
 			"liferay-ui:input-search:useNamespace", _useNamespace);
@@ -140,6 +147,7 @@ public class InputSearchTag extends IncludeTag {
 	private String _name;
 	private String _placeholder;
 	private boolean _showButton = true;
+	private boolean _showSearchCancel = false;
 	private String _title;
 	private boolean _useNamespace = true;
 


### PR DESCRIPTION
Hey Jon,

This update adds the input-search taglib to the portlet in both the main search and the results screen.  For the cancel button functionality, I added an attribute flag to the input-search taglib that allows the user to add the input-search field as a target for the A.ButtonSearchCancel module.  This functionality is completely dependent on an additional method in the AUI module, since to accomplish this I had to automatically instantiate the module in the bottom_js.jsp.  The mobile-only functionality of the module is still present.
