### PR TITLE
LPS-43745 - The remove page button is cutoff in a minimized interface

### DIFF
--- a/portal-web/docroot/html/themes/_styled/css/dockbar.css
+++ b/portal-web/docroot/html/themes/_styled/css/dockbar.css
@@ -15,7 +15,7 @@ $editLayoutPanelWidth: 460px;
 			position: absolute;
 			right: 0;
 			top: 0;
-			z-index: 301;
+			z-index: 400;
 
 			&.open {
 				display: block;


### PR DESCRIPTION
Hi Jon,

Attached is another update for https://issues.liferay.com/browse/LPS-43745.

This fix ensures the dockbar does not cover the delete tab of the first page in mobile view.

Please let me know if there are any issues.

Thanks!
