### PR TITLE
LPS-38538 A User cannot reduce the height or width of a freeform portlet

### DIFF
--- a/portal-web/docroot/html/themes/classic/_diffs/css/custom_common.css
+++ b/portal-web/docroot/html/themes/classic/_diffs/css/custom_common.css
@@ -820,6 +820,10 @@ $dockbarOpenGradientStart: #0EA6F9;
 		}
 	}
 
+	.yui3-resize-proxy {
+		z-index: auto;
+	}
+
 	/* ---------- Quick access ---------- */
 
 	.quick-access-nav {


### PR DESCRIPTION
Hi @jonmak08,

Here is an update for https://issues.liferay.com/browse/LPS-38538.

This issue has been reported to yui https://github.com/yui/yui3/issues/550, but after looking at it, I think we can easily fix it on our end. The cause of this issue is that the resize proxy node (z-index: 10000) has a higher z-index than the shim node (z-index:9999). The mousemove event is subscribed on the shim node. That's why when we mouse the resize handle over the proxy node, the mousemove event cannot be caught by the shim node as the resize proxy node is stacked on top of the shim node. Since the z-index for the proxy node is set in resize-base-core.css, I think we can just override it in our css files. The resize proxy seems to work fine with lower z-index. Let me know if there's any issues. Thanks!
