### PR TITLE
LPS-50085 - Last item displayed by the asset publisher should not have border/separator

### DIFF
--- a/portal-web/docroot/html/portlet/asset_publisher/css/main.css
+++ b/portal-web/docroot/html/portlet/asset_publisher/css/main.css
@@ -3,6 +3,10 @@
 		border-bottom: 1px solid #DDD;
 		padding: 0.6em 0;
 
+		&:last-child {
+			border-bottom-width: 0;
+		}
+
 		.asset-content p {
 			margin-bottom: 0;
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-50085
