### PR TITLE
LPS-50087 - input-asset-links taglib no longer needs separator

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_asset_links/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_asset_links/page.jsp
@@ -45,8 +45,6 @@
 
 <br />
 
-<div class="separator"><!-- --></div>
-
 <liferay-util:buffer var="removeLinkIcon">
 	<liferay-ui:icon
 		iconCssClass="icon-remove"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-50087
