### PR TITLE
LPS-51381 Page Name field disappears when switching locales in IE 9.

### DIFF
--- a/portal-web/docroot/html/js/liferay/input_localized.js
+++ b/portal-web/docroot/html/js/liferay/input_localized.js
@@ -275,7 +275,7 @@ AUI.add(
 
 							setTimeout(
 								function() {
-									input.addClass(animateClass).focus();
+									input.addClass(animateClass);
 								},
 								0
 							);


### PR DESCRIPTION
Hey Jon.

This is a fix for LPS-51381, which is about placeholder.

As IE does not support placeholder with its version below 10, it will trigger the form_placeholder.js which is for, I would say, emulating the placeholder because It does not behave the same as the browsers behave which support HTML5 placeholder.

In more details, it can not distinguish the input value typed by the user or by the placeholder.

Let's say the placeholder equals "Welcome".

If the "Welcome" is generated by place holder when the user Foucs on the input field, the value is removed makes sense.

However, if the "Welcome" is typed by the user or retrieved from the database, when Focusing on the input field, the "Welcome" is not expected to be removed.

Just refer to the code in form_placeholder.js

```
                    _togglePlaceholders: function(event) {
                        var instance = this;

                        var currentTarget = event.currentTarget;

                        if (currentTarget.hasAttribute(STR_DATA_TYPE_PASSWORD_PLACEHOLDER) || currentTarget.attr(STR_TYPE) === STR_PASSWORD) {
                            instance._togglePasswordPlaceholders(event, currentTarget);
                        }
                        else {
                            var placeholder = currentTarget.attr(STR_PLACEHOLDER);

                            if (placeholder) {
                                var value = currentTarget.val();

                                if (event.type === STR_FOCUS) {
                                    if (value === placeholder) {
                                        currentTarget.val(STR_BLANK);

                                        currentTarget.removeClass(CSS_PLACEHOLDER);
                                    }
                                }
                                else if (!value) {
                                    currentTarget.val(placeholder);

                                    currentTarget.addClass(CSS_PLACEHOLDER);
                                }
                            }
                        }
                    }
```

So now when the user clicks the US flag under page name, the page name input is foucsed and the value of it is removed as the form_placeholder considers the value as placeholder (The placeholder always equals the value of default language name.), which is not expected by the customer as he believes the name is the one he input.

I spent one day to figure out how to let the form_placeholer to distinguish just like HTML5 one but failed.

So I can only remove the focus to make it soft to the customer as the value of input is not removed immediately.

Let me know if you have any better ideas about this issue.

Thanks
John.
