### PR TITLE
LPS-51381 Page Name field disappears when switching locales in IE 9.

### DIFF
--- a/portal-web/docroot/html/js/liferay/input_localized.js
+++ b/portal-web/docroot/html/js/liferay/input_localized.js
@@ -275,7 +275,11 @@ AUI.add(
 
 							setTimeout(
 								function() {
-									input.addClass(animateClass).focus();
+									input.addClass(animateClass);
+
+									if (!Liferay.Browser.isIe() || Liferay.Browser.getMajorVersion() > 9) {
+										input.focus();
+									}
 								},
 								0
 							);


### PR DESCRIPTION
Hi Jonathan

This issue is a bit tricky. 

Our self-implemented place holder does not work as good as the one inherited from HTML5.

Every time when focusing on the input, if the value of input equals its placeholder, the value will be removed.

Because the place holder always equals the default language page name, every time when clicking the US flag, the "Welcome", which is the value of input and the place holder, will be removed.

This is not user-friendly.

I cannot figure out a workaround which removed the focus for IE versions< 9 as I have no idea how to distinguish place holder and value of input as long as they are identical.

For more information, please refer to https://github.com/jonmak08/liferay-portal/pull/1115.

Thanks
John.