### PR TITLE
LPS-52381 - In Documents and Media configuration, user cannot select a folder again after being de-selected.

### DIFF
--- a/modules/apps/bookmarks/bookmarks-web/docroot/html/portlet/bookmarks/edit_entry.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/docroot/html/portlet/bookmarks/edit_entry.jsp
@@ -129,7 +129,7 @@ boolean showHeader = ParamUtil.getBoolean(request, "showHeader", true);
 				</aui:script>
 
 				<%
-				String taglibRemoveFolder = "Liferay.Util.removeFolderSelection('folderId', 'folderName', '" + renderResponse.getNamespace() + "');";
+				String taglibRemoveFolder = "Liferay.Util.removeEntitySelection('folderId', 'folderName', this, '" + renderResponse.getNamespace() + "');";
 				%>
 
 				<aui:button disabled="<%= (folderId <= 0) %>" name="removeFolderButton" onClick="<%= taglibRemoveFolder %>" value="remove" />

--- a/modules/apps/bookmarks/bookmarks-web/docroot/html/portlet/bookmarks/edit_folder.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/docroot/html/portlet/bookmarks/edit_folder.jsp
@@ -123,7 +123,7 @@ else {
 				</aui:script>
 
 				<%
-				String taglibRemoveFolder = "Liferay.Util.removeFolderSelection('parentFolderId', 'parentFolderName', '" + renderResponse.getNamespace() + "');";
+				String taglibRemoveFolder = "Liferay.Util.removeEntitySelection('parentFolderId', 'parentFolderName', this, '" + renderResponse.getNamespace() + "');";
 				%>
 
 				<aui:button disabled="<%= (parentFolderId <= 0) %>" name="removeFolderButton" onClick="<%= taglibRemoveFolder %>" value="remove" />

--- a/modules/apps/bookmarks/bookmarks-web/docroot/html/portlet/bookmarks_admin/display_settings.jspf
+++ b/modules/apps/bookmarks/bookmarks-web/docroot/html/portlet/bookmarks_admin/display_settings.jspf
@@ -27,7 +27,7 @@
 				<aui:button name="selectFolderButton" value="select" />
 
 				<%
-				String taglibRemoveFolder = "Liferay.Util.removeFolderSelection('rootFolderId', 'rootFolderName', '" + renderResponse.getNamespace() + "');";
+				String taglibRemoveFolder = "Liferay.Util.removeEntitySelection('rootFolderId', 'rootFolderName', this, '" + renderResponse.getNamespace() + "');";
 				%>
 
 				<aui:button disabled="<%= rootFolderId <= 0 %>" name="removeFolderButton" onClick="<%= taglibRemoveFolder %>" value="remove" />

--- a/portal-web/docroot/html/js/liferay/util.js
+++ b/portal-web/docroot/html/js/liferay/util.js
@@ -1293,13 +1293,15 @@
 
 	Liferay.provide(
 		Util,
-		'removeFolderSelection',
-		function(folderIdString, folderNameString, namespace) {
-			A.byIdNS(namespace, folderIdString).val(0);
+		'removeEntitySelection',
+		function(entityIdString, entityNameString, removeEntityButton, namespace) {
+			A.byIdNS(namespace, entityIdString).val(0);
 
-			A.byIdNS(namespace, folderNameString).val('');
+			A.byIdNS(namespace, entityNameString).val('');
 
-			Liferay.Util.toggleDisabled(A.byIdNS(namespace, 'removeFolderButton'), true);
+			Liferay.Util.toggleDisabled(removeEntityButton, true);
+
+			Liferay.fire('entitySelectionRemoved');
 		},
 		['aui-base', 'liferay-node']
 	);
@@ -1486,6 +1488,12 @@
 					Util.getWindow().hide();
 				},
 				'.selector-button'
+			);
+
+			openingLiferay.on('entitySelectionRemoved',
+				function(event) {
+					selectorButtons.attr('disabled', false);
+				}
 			);
 		},
 		['aui-base']

--- a/portal-web/docroot/html/js/liferay/util.js
+++ b/portal-web/docroot/html/js/liferay/util.js
@@ -1464,14 +1464,18 @@
 		Util,
 		'selectEntityHandler',
 		function(container, selectEventName, disableButton) {
+			container = A.one(container);
 			var openingLiferay = Util.getOpener().Liferay;
+			var selectorButtons = container.all('.selector-button');
 
-			A.one(container).delegate(
+			container.delegate(
 				'click',
 				function(event) {
 					var currentTarget = event.currentTarget;
 
 					if (disableButton !== false) {
+						selectorButtons.attr('disabled', false);
+
 						currentTarget.attr('disabled', true);
 					}
 

--- a/portal-web/docroot/html/portlet/blogs_aggregator/configuration.jsp
+++ b/portal-web/docroot/html/portlet/blogs_aggregator/configuration.jsp
@@ -48,7 +48,11 @@ if (organizationId > 0) {
 
 			<aui:button name="selectOrganizationButton" value="select" />
 
-			<aui:button disabled="<%= organizationId <= 0 %>" name="removeOrganizationButton" onClick='<%= renderResponse.getNamespace() + "removeOrganization();" %>' value="remove" />
+			<%
+			String taglibRemoveFolder = "Liferay.Util.removeEntitySelection('organizationId', 'organizationName', this, '" + renderResponse.getNamespace() + "');";
+			%>
+
+			<aui:button disabled="<%= organizationId <= 0 %>" name="removeOrganizationButton" onClick="<%= taglibRemoveFolder %>" value="remove" />
 		</div>
 
 		<aui:select name="preferences--displayStyle--" value="<%= displayStyle %>">
@@ -99,14 +103,6 @@ if (organizationId > 0) {
 </aui:form>
 
 <aui:script>
-	function <portlet:namespace />removeOrganization() {
-		document.<portlet:namespace />fm.<portlet:namespace />organizationId.value = '';
-
-		document.getElementById('<portlet:namespace />organizationName').value = '';
-
-		Liferay.Util.toggleDisabled('#<portlet:namespace />removeOrganizationButton', true);
-	}
-
 	AUI.$('#<portlet:namespace />selectOrganizationButton').on(
 		'click',
 		function(event) {

--- a/portal-web/docroot/html/portlet/document_library/configuration.jsp
+++ b/portal-web/docroot/html/portlet/document_library/configuration.jsp
@@ -53,7 +53,7 @@ DLConfigurationDisplayContext dlConfigurationDisplayContext = new DLConfiguratio
 							<aui:button name="selectFolderButton" value="select" />
 
 							<%
-							String taglibRemoveFolder = "Liferay.Util.removeFolderSelection('rootFolderId', 'rootFolderName', '" + renderResponse.getNamespace() + "');";
+							String taglibRemoveFolder = "Liferay.Util.removeEntitySelection('rootFolderId', 'rootFolderName', this, '" + renderResponse.getNamespace() + "');";
 							%>
 
 							<aui:button disabled="<%= rootFolderId <= 0 %>" name="removeFolderButton" onClick="<%= taglibRemoveFolder %>" value="remove" />

--- a/portal-web/docroot/html/portlet/document_library/edit_file_entry.jsp
+++ b/portal-web/docroot/html/portlet/document_library/edit_file_entry.jsp
@@ -271,7 +271,7 @@ else {
 				<aui:button name="selectFolderButton" value="select" />
 
 				<%
-				String taglibRemoveFolder = "Liferay.Util.removeFolderSelection('folderId', 'folderName', '" + renderResponse.getNamespace() + "');";
+				String taglibRemoveFolder = "Liferay.Util.removeEntitySelection('folderId', 'folderName', this, '" + renderResponse.getNamespace() + "');";
 				%>
 
 				<aui:button disabled="<%= folderId <= 0 %>" name="removeFolderButton" onClick="<%= taglibRemoveFolder %>" value="remove" />

--- a/portal-web/docroot/html/portlet/document_library_display/configuration.jsp
+++ b/portal-web/docroot/html/portlet/document_library_display/configuration.jsp
@@ -56,7 +56,7 @@ DLDisplayConfigurationDisplayContext dlDisplayConfigurationDisplayContext = new 
 					<aui:button name="openFolderSelectorButton" value="select" />
 
 					<%
-					String taglibRemoveFolder = "Liferay.Util.removeFolderSelection('rootFolderId', 'rootFolderName', '" + renderResponse.getNamespace() + "');";
+					String taglibRemoveFolder = "Liferay.Util.removeEntitySelection('rootFolderId', 'rootFolderName', this, '" + renderResponse.getNamespace() + "');";
 					%>
 
 					<aui:button disabled="<%= rootFolderId <= 0 %>" name="removeFolderButton" onClick="<%= taglibRemoveFolder %>" value="remove" />

--- a/portal-web/docroot/html/portlet/image_gallery_display/configuration.jsp
+++ b/portal-web/docroot/html/portlet/image_gallery_display/configuration.jsp
@@ -85,7 +85,7 @@ IGConfigurationDisplayContext igConfigurationDisplayContext = new IGConfiguratio
 						<aui:button name="openFolderSelectorButton" value="select" />
 
 						<%
-						String taglibRemoveFolder = "Liferay.Util.removeFolderSelection('rootFolderId', 'rootFolderName', '" + renderResponse.getNamespace() + "');";
+						String taglibRemoveFolder = "Liferay.Util.removeEntitySelection('rootFolderId', 'rootFolderName', this, '" + renderResponse.getNamespace() + "');";
 						%>
 
 						<aui:button disabled="<%= rootFolderId <= 0 %>" name="removeFolderButton" onClick="<%= taglibRemoveFolder %>" value="remove" />

--- a/portal-web/docroot/html/portlet/journal/edit_folder.jsp
+++ b/portal-web/docroot/html/portlet/journal/edit_folder.jsp
@@ -124,7 +124,7 @@ if (workflowEnabled) {
 					</aui:script>
 
 					<%
-					String taglibRemoveFolder = "Liferay.Util.removeFolderSelection('parentFolderId', 'parentFolderName', '" + renderResponse.getNamespace() + "');";
+					String taglibRemoveFolder = "Liferay.Util.removeEntitySelection('parentFolderId', 'parentFolderName', this, '" + renderResponse.getNamespace() + "');";
 					%>
 
 					<aui:button disabled="<%= (parentFolderId <= 0) %>" name="removeFolderButton" onClick="<%= taglibRemoveFolder %>" value="remove" />

--- a/portal-web/docroot/html/portlet/message_boards/move_category.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/move_category.jsp
@@ -62,7 +62,11 @@ long parentCategoryId = BeanParamUtil.getLong(category, request, "parentCategory
 
 			<aui:button name="selectCategoryButton" value="select" />
 
-			<aui:button disabled="<%= (parentCategoryId <= 0) %>" name="removeCategoryButton" onClick='<%= renderResponse.getNamespace() + "removeCategory();" %>' value="remove" />
+			<%
+			String taglibRemoveFolder = "Liferay.Util.removeEntitySelection('parentCategoryId', 'parentCategoryName', this, '" + renderResponse.getNamespace() + "');";
+			%>
+
+			<aui:button disabled="<%= (parentCategoryId <= 0) %>" name="removeCategoryButton" onClick="<%= taglibRemoveFolder %>" value="remove" />
 		</div>
 
 		<aui:input label="merge-with-parent-category" name="mergeWithParentCategory" type="checkbox" />
@@ -74,16 +78,6 @@ long parentCategoryId = BeanParamUtil.getLong(category, request, "parentCategory
 		<aui:button href="<%= redirect %>" type="cancel" />
 	</aui:button-row>
 </aui:form>
-
-<aui:script>
-	function <portlet:namespace />removeCategory() {
-		document.<portlet:namespace />fm.<portlet:namespace />parentCategoryId.value = '<%= MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID %>';
-
-		document.getElementById('<portlet:namespace />parentCategoryName').value = '';
-
-		Liferay.Util.toggleDisabled('#<portlet:namespace />removeCategoryButton', true);
-	}
-</aui:script>
 
 <%
 if (category != null) {

--- a/portal-web/docroot/html/portlet/recent_bloggers/configuration.jsp
+++ b/portal-web/docroot/html/portlet/recent_bloggers/configuration.jsp
@@ -48,7 +48,11 @@ if (organizationId > 0) {
 
 			<aui:button name="selectOrganizationButton" value="select" />
 
-			<aui:button disabled="<%= organizationId <= 0 %>" name="removeOrganizationButton" onClick='<%= renderResponse.getNamespace() + "removeOrganization();" %>' value="remove" />
+			<%
+			String taglibRemoveFolder = "Liferay.Util.removeEntitySelection('organizationId', 'organizationName', this, '" + renderResponse.getNamespace() + "');";
+			%>
+
+			<aui:button disabled="<%= organizationId <= 0 %>" name="removeOrganizationButton" onClick="<%= taglibRemoveFolder %>" value="remove" />
 		</div>
 
 		<aui:select name="preferences--displayStyle--">
@@ -108,16 +112,6 @@ if (organizationId > 0) {
 			);
 		}
 	);
-
-	function <portlet:namespace />removeOrganization() {
-		var form = AUI.$(document.<portlet:namespace />fm);
-
-		form.fm('organizationId').val('');
-
-		form.fm('organizationName').val('');
-
-		Liferay.Util.toggleDisabled('#<portlet:namespace />removeOrganizationButton', true);
-	}
 
 	Liferay.Util.toggleSelectBox('<portlet:namespace />selectionMethod', 'users', '<portlet:namespace />UsersSelectionOptions');
 </aui:script>

--- a/portal-web/docroot/html/portlet/shopping/edit_category.jsp
+++ b/portal-web/docroot/html/portlet/shopping/edit_category.jsp
@@ -105,9 +105,7 @@ long parentCategoryId = BeanParamUtil.getLong(category, request, "parentCategory
 
 		var form = $(document.<portlet:namespace />fm);
 
-		form.fm('parentCategoryId').val('<%= ShoppingCategoryConstants.DEFAULT_PARENT_CATEGORY_ID %>');
-
-		form.fm('parentCategoryName').val('');
+		Liferay.Util.removeEntitySelection('parentCategoryId', 'parentCategoryName', this, '<portlet:namespace />');
 
 		$('#<portlet:namespace />mergeParentCheckboxDiv').addClass('hide');
 

--- a/portal-web/docroot/html/portlet/shopping/edit_item.jsp
+++ b/portal-web/docroot/html/portlet/shopping/edit_item.jsp
@@ -128,7 +128,11 @@ int priceId = ParamUtil.getInteger(request, "priceId", -1);
 
 				<aui:button id="selectCategoryButton" value="select" />
 
-				<aui:button onClick='<%= renderResponse.getNamespace() + "removeCategory();" %>' value="remove" />
+				<%
+				String taglibRemoveFolder = "Liferay.Util.removeEntitySelection('categoryId', 'categoryName', this, '" + renderResponse.getNamespace() + "');";
+				%>
+
+				<aui:button onClick="<%= taglibRemoveFolder %>" value="remove" />
 			</div>
 
 			<aui:script sandbox="<%= true %>">
@@ -607,14 +611,6 @@ int priceId = ParamUtil.getInteger(request, "priceId", -1);
 				uri: itemQuantitiesURL
 			}
 		);
-	}
-
-	function <portlet:namespace />removeCategory() {
-		var form = AUI.$(document.<portlet:namespace />fm);
-
-		form.fm('categoryId').val('<%= ShoppingCategoryConstants.DEFAULT_PARENT_CATEGORY_ID %>');
-
-		form.fm('categoryName').val('');
 	}
 
 	function <portlet:namespace />saveItem() {


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-52381.

This issue was present most places where we are using Liferay.Util.selectEntity like selecting a category, folder, organization etc... So I tried to make a fix in util.js that would fix all of these areas.  

I also converted the removeFolderSelection method to removeEntitySelection so that it can be used more places and cut down on duplicate code.

If you think this change is too large for this issue or it should be handled in a more case by cases basis, just let me know and I can work on individual fixes for these issues.

Thanks!