### PR TITLE
LPS-51798 - Can't add uninstantiable portlet to page after copy portlet from page action

### DIFF
--- a/portal-impl/src/com/liferay/portlet/sites/action/ActionUtil.java
+++ b/portal-impl/src/com/liferay/portlet/sites/action/ActionUtil.java
@@ -57,7 +57,16 @@ public class ActionUtil
 		LayoutTypePortlet sourceLayoutTypePortlet =
 			(LayoutTypePortlet)sourceLayout.getLayoutType();
 
+		LayoutTypePortlet targetLayoutTypePortlet =
+			(LayoutTypePortlet)targetLayout.getLayoutType();
+
 		List<String> sourcePortletIds = sourceLayoutTypePortlet.getPortletIds();
+
+		List<String> targetPortletIds = targetLayoutTypePortlet.getPortletIds();
+
+		for (String targetPortletId : targetPortletIds) {
+			targetLayoutTypePortlet.removePortletId(themeDisplay.getUserId(), targetPortletId);
+		}
 
 		for (String sourcePortletId : sourcePortletIds) {
 


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-51798.

To fix this one, I made sure to remove the old portlet ids from the layout in the copyPreferences method.

Please let me know if there are any issues.

Thanks!