### PR TITLE
LPS-51798 - Can't add uninstantiable portlet to page after copy portlet from page action

### DIFF
--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
@@ -1031,6 +1031,8 @@ public class EditLayoutsAction extends PortletAction {
 							layoutTypeSettingsProperties =
 								copyLayout.getTypeSettingsProperties();
 
+							ActionUtil.removePortletIds(actionRequest, layout);
+
 							ActionUtil.copyPreferences(
 								actionRequest, layout, copyLayout);
 

--- a/portal-impl/src/com/liferay/portlet/sites/action/ActionUtil.java
+++ b/portal-impl/src/com/liferay/portlet/sites/action/ActionUtil.java
@@ -23,6 +23,7 @@ import com.liferay.portal.model.MembershipRequest;
 import com.liferay.portal.model.PortletPreferencesIds;
 import com.liferay.portal.model.Team;
 import com.liferay.portal.service.GroupLocalServiceUtil;
+import com.liferay.portal.service.LayoutServiceUtil;
 import com.liferay.portal.service.MembershipRequestLocalServiceUtil;
 import com.liferay.portal.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.service.TeamLocalServiceUtil;
@@ -199,4 +200,35 @@ public class ActionUtil
 		getTeam(request);
 	}
 
+	public static void removePortletIds(
+			HttpServletRequest request, Layout layout)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		LayoutTypePortlet layoutTypePortlet =
+			(LayoutTypePortlet)layout.getLayoutType();
+
+		List<String> portletIds = layoutTypePortlet.getPortletIds();
+
+		for (String portletId : portletIds) {
+			layoutTypePortlet.removePortletId(
+				themeDisplay.getUserId(), portletId);
+		}
+
+		LayoutServiceUtil.updateLayout(
+			layout.getGroupId(), layout.isPrivateLayout(),
+			layout.getLayoutId(), layout.getTypeSettings());
+	}
+
+	public static void removePortletIds(
+			PortletRequest portletRequest, Layout layout)
+		throws Exception {
+
+		HttpServletRequest request = PortalUtil.getHttpServletRequest(
+			portletRequest);
+
+		removePortletIds(request, layout);
+	}
 }


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-51798.

I modified my original fix based on Brian's comments in https://github.com/brianchandotcom/liferay-portal/pull/23079.

I added a separate method to ActionUtil for removing the portlet ids from the layout.

Please let me know if there are any issues.

Thanks!