### PR TITLE
LPS-53410 - document entry title too short will shift thumbnail to cover checkbox

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/css/main.css
+++ b/portal-web/docroot/html/portlet/document_library/css/main.css
@@ -326,8 +326,12 @@
 	}
 
 	.app-view-entry-taglib.entry-display-style.display-icon {
-		.entry-thumbnail .taglib-workflow-status {
-			left: 6px;
+		.entry-thumbnail {
+			min-width: 151px;
+
+			.taglib-workflow-status {
+				left: 6px;
+			}
 		}
 
 		.entry-title {


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-53410.

Please let me know if there are any issues.

Thanks!