### PR TITLE
LPS-41961 - CKEditor does not work if you move the portlets around

### DIFF
--- a/portal-web/docroot/html/js/liferay/layout.js
+++ b/portal-web/docroot/html/js/liferay/layout.js
@@ -400,6 +400,8 @@ AUI.add(
 				Liferay.on('closePortlet', Layout._onPortletClose);
 
 				Layout.INITIALIZED = true;
+
+				Liferay.fire('layoutInitialized');
 			},
 			[layoutModule]
 		);


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-41961.

This is a larger change than I had originally intended to make for this issue.  But the only solution I could find was to destroy the ckeditor instance when the user starts to drag the portlet, and recreate it when it is dropped.

I think this fix will work in 6.2 as well, but will require moving some code around because it looks like some of ckeditor.jsp has been refactored.  I could send a separate pull for that if you think I should.

Please let me know your thoughts.

Thanks!
