### PR TITLE
LPS-53769 - Content saved using TinyMCE does not save the formatting of content

### DIFF
--- a/portal-web/docroot/html/js/editor/tinymce.jsp
+++ b/portal-web/docroot/html/js/editor/tinymce.jsp
@@ -141,7 +141,7 @@ String toolbarSet = (String)request.getAttribute("liferay-ui:input-editor:toolba
 				}
 			}
 			else {
-				data = tinyMCE.editors['<%= name %>'].getBody().textContent;
+				data = tinyMCE.editors['<%= name %>'].getBody().innerHTML;
 			}
 
 			return data;


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-53769.

I think this is a better solution than my original fix.  This way the html that is saved is limited to what is just in the body element of the iframe.  But the blogs issue you found in the other fix could still occur, if the user adds any html formatting to the title or subtitle fields.  I think it may be best to move that to a separate issue.

Please let me know if there are any issues.

Thanks!