### PR TITLE
LPS-47824 - Page title editor is misaligned

### DIFF
--- a/portal-web/docroot/html/themes/_styled/css/navigation.css
+++ b/portal-web/docroot/html/themes/_styled/css/navigation.css
@@ -59,6 +59,8 @@
 	.lfr-nav-updateable {
 		.add-page-editor {
 			.add-page-editor-input {
+				height: 36px;
+				margin: 0;
 				width: 150px;
 			}
 


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-47824.

I think there could be a few different solutions on how to align/size the input and the button on this one.  But I went with setting a fixed height and no margin because it seems to be the most consistent across browsers.

Please let me know if there are any issues or if you think it should be done a different way.

Thanks!