### PR TITLE
LPS-55198 - reposition close btn in modal header for narrow view

### DIFF
--- a/portal-web/docroot/html/css/taglib/button.css
+++ b/portal-web/docroot/html/css/taglib/button.css
@@ -53,6 +53,7 @@
 
 	@media (max-width: 480px) {
 		.modal-header button.close {
+			margin-top: -10px;
 			padding: 12px;
 		}
 	}


### PR DESCRIPTION
Hey @jonmak08 

Here is an update for [LPS-55198](https://issues.liferay.com/browse/LPS-55198).
In 6.2.x the close btn had `margin: -10px;`  but it seemed best to only apply the negative margin to the top to fix this issue. Let me know if you have any questions.