### PR TITLE
LPS-56800 - build-alloy-theme ant task in frontend-themes-web does not completely copy images from alloy

### DIFF
--- a/modules/frontend/frontend-themes-web/build.xml
+++ b/modules/frontend/frontend-themes-web/build.xml
@@ -140,10 +140,12 @@
 					<available file="${alloy.dir}/${dir.name}/assets/skins/sam" />
 					<then>
 						<copy todir="${themes.dir}/_unstyled/images/aui" preservelastmodified="true">
-							<fileset dir="{alloy.dir}/${dir.name}/assets/skins/sam" includes="**/*.png,**/*.jpg,**/*.gif" />
+							<fileset dir="${alloy.dir}/${dir.name}/assets/skins/sam" includes="**/*.png,**/*.jpg,**/*.gif" />
 						</copy>
 					</then>
 				</if>
+
+				<var name="dir.name" unset="true" />
 			</sequential>
 		</for>
 


### PR DESCRIPTION
Hey Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-56800.

This is a fix for an issue I caused when I overlooked something when migrating ant tasks for the js module here 2d48949ede0c7e7cf3f757b56e9e397c397edada

Please let me know if there are any issues.

Thanks!