### PR TITLE
LPS-39153

### DIFF
--- a/modules/apps/user-personal-bar/user-personal-bar-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/user-personal-bar/user-personal-bar-web/src/META-INF/resources/view.jsp
@@ -35,7 +35,7 @@
 	</c:choose>
 
 	<span class="user-full-name">
-		<%= HtmlUtil.escape(user.getFullName()) %>
+		<%= HtmlUtil.escape(user.getShortFullName(17)) %>
 	</span>
 </liferay-util:buffer>
 

--- a/modules/frontend/frontend-js-web/src/META-INF/resources/html/js/liferay/dockbar.js
+++ b/modules/frontend/frontend-js-web/src/META-INF/resources/html/js/liferay/dockbar.js
@@ -22,6 +22,26 @@ AUI.add(
 
 					Liferay.once('initDockbar', instance._init, instance);
 
+					var navAccountControls = dockBar.one(SELECTOR_NAV_ACCOUNT_CONTROLS);
+
+					if (navAccountControls) {
+						var dropdown = navAccountControls.all('li.dropdown');
+
+						if (dropdown) {
+							dropdown.each(instance._setDropdownWidth);
+
+							A.getWin().on(
+								'resize',
+								A.debounce(
+									function() {
+										dropdown.each(instance._setDropdownWidth);
+									},
+									100
+								)
+							);
+						}
+					}
+
 					var eventHandle = dockBar.on(
 						['focus', 'mousemove', 'touchstart'],
 						function(event) {
@@ -57,6 +77,16 @@ AUI.add(
 					BODY.addClass('dockbar-ready');
 
 					Liferay.on(['noticeHide', 'noticeShow'], instance._toggleControlsOffset, instance);
+				}
+			},
+
+			_setDropdownWidth: function(item) {
+				var dropdownMenu = item.one('.dropdown-menu');
+
+				if (dropdownMenu) {
+					var dropdownWidth = item.get('offsetWidth');
+
+					dropdownMenu.setStyle('min-width', dropdownWidth);
 				}
 			},
 

--- a/modules/frontend/frontend-themes-web/src/META-INF/resources/html/themes/classic/_diffs/css/custom.css
+++ b/modules/frontend/frontend-themes-web/src/META-INF/resources/html/themes/classic/_diffs/css/custom.css
@@ -124,6 +124,20 @@ html {
 		.nav-account-controls {
 			background-color: transparent;
 
+			.admin-links {
+				min-width: 175px;
+			}
+
+			.my-sites, .user-avatar {
+				min-width: 160px;
+			}
+
+			@include respond-to(phone, tablet) {
+				.admin-links, .my-sites, .user-avatar {
+					min-width: 0;
+				}
+			}
+
 			.navbar-nav > li > a {
 				&:focus, &:hover {
 					background-color: #2FA4F5;

--- a/modules/frontend/frontend-themes-web/src/META-INF/resources/html/themes/control_panel/_diffs/css/custom.css
+++ b/modules/frontend/frontend-themes-web/src/META-INF/resources/html/themes/control_panel/_diffs/css/custom.css
@@ -260,6 +260,20 @@ h3 {
 			background-color: transparent;
 			float: right;
 
+			.admin-links {
+				min-width: 175px;
+			}
+
+			.my-sites, .user-avatar {
+				min-width: 160px;
+			}
+
+			@include respond-to(phone, tablet) {
+				.admin-links, .my-sites, .user-avatar {
+					min-width: 0;
+				}
+			}
+
 			@include justify-content(flex-end);
 
 			> li.open > .dropdown-toggle {

--- a/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
@@ -759,6 +759,10 @@ public class UserImpl extends UserBaseImpl {
 		return RoleLocalServiceUtil.getUserRoles(getUserId());
 	}
 
+	public String getShortFullName(int length) {
+		return StringUtil.truncateMiddle(getFullName(), length);
+	}
+
 	@Override
 	public List<Group> getSiteGroups() throws PortalException {
 		return getSiteGroups(false);

--- a/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -237,6 +237,53 @@ public class StringUtil {
 	}
 
 	/**
+	 * Returns the original string truncated in the middle to a specified
+	 * length
+	 *
+	 * <p>
+	 * Example:
+	 * </p>
+	 *
+	 * <p>
+	 * <pre>
+	 * <code>
+	 * truncateMiddle("abcdefghijklm", 9) returns "abc...klm"
+	 * truncateMiddle("abcdefghijk lmnopq", 15) returns "abcdef...lmnopq"
+	 * truncateMiddle("abcdefghijk lmnopq", 18) returns "abcdefgh... lmnopq"
+	 * truncateMiddle("abcde ijkl", 10) returns "abcde ijkl"
+	 * </code>
+	 * </pre>
+	 * </p>
+	 *
+	 * @param  s the string to truncate in the middle
+	 * @param  length the length to reduce the string to
+	 * @return the truncated string
+	 */
+	public static String truncateMiddle(String s, int length) {
+		int stringLength = s.length();
+
+		if (stringLength <= length) {
+			return s;
+		}
+
+		int evenOdd = 3;
+
+		if (length % 2 == 0) {
+			length -= 1;
+			evenOdd = 4;
+		}
+
+		int halfLength = (length - 3)/2;
+
+		int nameBeginLength = halfLength + evenOdd;
+
+		String nameBegin = shorten(s, nameBeginLength, StringPool.TRIPLE_PERIOD);
+		String nameEnd = s.substring(stringLength - halfLength);
+
+		return nameBegin + nameEnd;
+	}
+
+	/**
 	 * Returns <code>true</code> if the string contains the text as a comma
 	 * delimited list entry.
 	 *

--- a/portal-service/src/com/liferay/portal/model/User.java
+++ b/portal-service/src/com/liferay/portal/model/User.java
@@ -385,6 +385,8 @@ public interface User extends UserModel, PersistedModel {
 
 	public java.util.List<com.liferay.portal.model.Role> getRoles();
 
+	public java.lang.String getShortFullName(int length);
+
 	public java.util.List<com.liferay.portal.model.Group> getSiteGroups()
 		throws com.liferay.portal.kernel.exception.PortalException;
 

--- a/portal-service/src/com/liferay/portal/model/UserWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/UserWrapper.java
@@ -1254,6 +1254,11 @@ public class UserWrapper implements User, ModelWrapper<User> {
 	}
 
 	@Override
+	public java.lang.String getShortFullName(int length) {
+		return _user.getShortFullName(length);
+	}
+
+	@Override
 	public java.util.List<com.liferay.portal.model.Group> getSiteGroups()
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _user.getSiteGroups();


### PR DESCRIPTION
Hey @jonmak08 

Here is an update for [LPS-39153](https://issues.liferay.com/browse/LPS-39153).
I'm not sure if we even want to match the dropdown menus with their parent elements in the dockbar anymore so it is fine if we just revert that. Also, there was one issue I ran in to. When the dropdowns are closed their `offsetWidth` is 0 so when there is a site name that is really long and the dropdown is wider than the parent anchor I can't get the width of the dropdown an apply it to the anchor. It can be done using jquery's `node.css('width')` but that didn't seem like the way to go so I'm kinda stumped on how to do it. Let me know what you think and if you have any questions.
