### PR TITLE
LPS-57261 - Missing success and error messages in portal

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
@@ -834,6 +834,15 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 
 		mergePublicRenderParameters(dynamicRequest, preferences, plid);
 
+		HttpServletRequest originalRequest =
+			PortalUtil.getOriginalServletRequest(dynamicRequest);
+
+		HttpSession session = originalRequest.getSession();
+
+		if (Validator.isNull(session)) {
+			session = dynamicRequest.getSession();
+		}
+
 		_request = dynamicRequest;
 		_originalRequest = request;
 		_wapTheme = BrowserSnifferUtil.isWap(_request);
@@ -844,7 +853,7 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 		_portletMode = portletMode;
 		_preferences = preferences;
 		_session = new PortletSessionImpl(
-			_request.getSession(), _portletContext, _portletName, plid);
+			session, _portletContext, _portletName, plid);
 
 		String remoteUser = request.getRemoteUser();
 


### PR DESCRIPTION
Hey Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-57261.

I know this bug is caused by this commit: 7913a687d662a942ce3c3889368ab03356d8956d.

My fix should solve the alert messages issue without undoing Ray's fix, by using the original session in PortletRequestImpl.

Everything seems to work, but @rotty3000 may want to take a look just to make sure I'm not breaking anything in his fix that I'm not noticing.

Thanks!