### PR TITLE
LPS-57580 - "TypeError: Liferay.Portlet.loadCSSEditor is not a function" thrown when clicking Look and Feel on any portlet

### DIFF
--- a/modules/apps/portlet-css/portlet-css-web/src/com/liferay/portlet/css/web/servlet/taglib/PortletCSSBottomDynamicInclude.java
+++ b/modules/apps/portlet-css/portlet-css-web/src/com/liferay/portlet/css/web/servlet/taglib/PortletCSSBottomDynamicInclude.java
@@ -59,7 +59,7 @@ public class PortletCSSBottomDynamicInclude extends BaseDynamicInclude {
 
 	@Override
 	public void register(DynamicIncludeRegistry dynamicIncludeRegistry) {
-		dynamicIncludeRegistry.register("/html/common/themes/bottom-ext.jsp");
+		dynamicIncludeRegistry.register("/html/common/themes/bottom.jsp#post");
 	}
 
 	@Reference(target = "(osgi.web.symbolicname=com.liferay.portlet.css.web)")

--- a/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/servlet/taglib/MonitoringBottomDynamicInclude.java
+++ b/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/servlet/taglib/MonitoringBottomDynamicInclude.java
@@ -93,7 +93,7 @@ public class MonitoringBottomDynamicInclude extends BaseDynamicInclude {
 
 	@Override
 	public void register(DynamicIncludeRegistry dynamicIncludeRegistry) {
-		dynamicIncludeRegistry.register("/html/common/themes/bottom-ext.jsp");
+		dynamicIncludeRegistry.register("/html/common/themes/bottom.jsp#post");
 	}
 
 	@Activate


### PR DESCRIPTION
Hey Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-57580.

This bug was caused by https://issues.liferay.com/browse/LPS-57517, because they updated the dynamic include key (7345cf176592a7ba8b7cf49f74f2bc117e0684d6).

Please let me know if there are any issues.

Thanks!