### PR TITLE
LPS-57763 - Cancel button doesn't close iframe

### DIFF
--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -24,14 +24,22 @@
 
 	<c:choose>
 		<c:when test="<%= themeDisplay.isStatePopUp() || Validator.isNotNull(controlPanelCategory) %>">
-			Liferay.Util.getTop().Liferay.fire(
-				'popupReady',
-				{
-					doc: document,
-					win: window,
-					windowName: Liferay.Util.getWindowName()
-				}
-			);
+			function firePopupReady() {
+				Liferay.Util.getTop().Liferay.fire(
+					'popupReady',
+					{
+						doc: document,
+						win: window,
+						windowName: Liferay.Util.getWindowName()
+					}
+				);
+			}
+
+			firePopupReady();
+
+			<c:if test="<%= PropsValues.JAVASCRIPT_SINGLE_PAGE_APPLICATION_ENABLED %>">
+				Liferay.on('surfaceEndNavigate', firePopupReady);
+			</c:if>
 		</c:when>
 		<c:otherwise>
 


### PR DESCRIPTION
Hey Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-57763.

These changes will cause the popupReady event to fire on every surface load in a dialog, assuring the cancel button will always have a listener.  I think this is just one way we could solve the issue though, but seems like the simplest.  

Another option would be to extract out the button logic from the afterIframeLoaded method in util.js, and just call that directly on every surface load.

Please let me know if there are any issues.

Thanks