### PR TITLE
LPS-58079 - require aui-component in liferay-alloy-editor

### DIFF
--- a/modules/frontend/frontend-js-web/src/META-INF/resources/liferay/alloyeditor.js
+++ b/modules/frontend/frontend-js-web/src/META-INF/resources/liferay/alloyeditor.js
@@ -217,6 +217,6 @@ AUI.add(
 	},
 	'',
 	{
-		requires: ['alloy-editor', 'liferay-portlet-base']
+		requires: ['alloy-editor', 'aui-component', 'liferay-portlet-base']
 	}
 );

--- a/modules/frontend/frontend-js-web/src/META-INF/resources/liferay/modules.js
+++ b/modules/frontend/frontend-js-web/src/META-INF/resources/liferay/modules.js
@@ -59,6 +59,7 @@
 						path: 'alloyeditor.js',
 						requires: [
 							'alloy-editor',
+							'aui-component',
 							'liferay-portlet-base'
 						]
 					},


### PR DESCRIPTION
Hey Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-58079.

This bug has been around for a while, it was just exposed recently by LPS-57505.  Before those changes blogs didn't open in a maximized state, so chances are aui-component was loaded.  But after those changes, when not logged in there is nothing on the page using aui-component, hence the error.  

Please let me know if there are any issues.

Thanks!