### PR TITLE
LPS-58716 Redundancy in titles when setting new password and reminder queries

### DIFF
--- a/portal-web/docroot/html/portal/update_password.jsp
+++ b/portal-web/docroot/html/portal/update_password.jsp
@@ -55,10 +55,6 @@ PasswordPolicy passwordPolicy = user.getPasswordPolicy();
 			<aui:input name="<%= WebKeys.REFERER %>" type="hidden" value="<%= referer %>" />
 			<aui:input name="ticketKey" type="hidden" value="<%= ticketKey %>" />
 
-			<div class="alert alert-info">
-				<liferay-ui:message key="please-set-a-new-password" />
-			</div>
-
 			<c:if test="<%= !SessionErrors.isEmpty(request) %>">
 				<div class="alert alert-danger">
 					<c:choose>
@@ -115,10 +111,16 @@ PasswordPolicy passwordPolicy = user.getPasswordPolicy();
 				</div>
 			</c:if>
 
-			<aui:fieldset label="new-password">
-				<aui:input autoFocus="<%= true %>" class="lfr-input-text-container" label="password" name="password1" type="password" />
+			<aui:fieldset>
+				<aui:input autoFocus="<%= true %>" class="lfr-input-text-container" label="password" name="password1" showRequiredLabel="<%= false %>" type="password">
+					<aui:validator name="required" />
+				</aui:input>
 
-				<aui:input class="lfr-input-text-container" label="enter-again" name="password2" type="password" />
+				<aui:input class="lfr-input-text-container" label="enter-again" name="password2" showRequiredLabel="<%= false %>" type="password">
+					<aui:validator name="equalTo">
+						'#<portlet:namespace />password1'
+					</aui:validator>
+				</aui:input>
 			</aui:fieldset>
 
 			<aui:button-row>

--- a/portal-web/docroot/html/portal/update_reminder_query.jsp
+++ b/portal-web/docroot/html/portal/update_reminder_query.jsp
@@ -32,17 +32,13 @@ if (referer.equals(themeDisplay.getPathMain() + "/portal/update_reminder_query")
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
 	<aui:input name="<%= WebKeys.REFERER %>" type="hidden" value="<%= referer %>" />
 
-	<div class="alert alert-info">
-		<liferay-ui:message key="please-choose-a-reminder-query" />
-	</div>
-
 	<c:if test="<%= SessionErrors.contains(request, UserReminderQueryException.class.getName()) %>">
 		<div class="alert alert-danger">
 			<liferay-ui:message key="reminder-query-and-answer-cannot-be-empty" />
 		</div>
 	</c:if>
 
-	<aui:fieldset label="password-reminder">
+	<aui:fieldset>
 		<%@ include file="/html/portal/update_reminder_query_question.jspf" %>
 
 		<c:if test="<%= PropsValues.USERS_REMINDER_QUERIES_CUSTOM_QUESTION_ENABLED %>">
@@ -51,7 +47,9 @@ if (referer.equals(themeDisplay.getPathMain() + "/portal/update_reminder_query")
 			</div>
 		</c:if>
 
-		<aui:input cssClass="reminder-query-answer" label="answer" maxlength="<%= ModelHintsConstants.TEXT_MAX_LENGTH %>" name="reminderQueryAnswer" size="50" type="text" value="<%= user.getReminderQueryAnswer() %>" />
+		<aui:input cssClass="reminder-query-answer" label="answer" maxlength="<%= ModelHintsConstants.TEXT_MAX_LENGTH %>" name="reminderQueryAnswer" showRequiredLabel="<%= false %>" size="50" type="text" value="<%= user.getReminderQueryAnswer() %>">
+			<aui:validator name="required" />
+		</aui:input>
 	</aui:fieldset>
 
 	<aui:button-row>


### PR DESCRIPTION
Hey Jon,

These changes are based on the proposal made by Juan Hidalgo. Please see https://www.dropbox.com/s/oo4hx29tgnc3f4h/Screenshot%202015-09-09%2013.09.35.png?dl=0. 

- Remove the message of “Please set a new password”.
- Remove redundant fieldset title “New Password”
- The button Save, should be disabled while both fields are not perfectly filled.