### PR TITLE
LPS-59112 - Editing the portlet title throws "TypeError: portletTitle Text is null" in browser

### DIFF
--- a/modules/apps/portlet-css/portlet-css-web/src/META-INF/resources/js/look_and_feel.js
+++ b/modules/apps/portlet-css/portlet-css-web/src/META-INF/resources/js/look_and_feel.js
@@ -1313,8 +1313,10 @@ AUI.add(
 							if (portletLanguage == instance._currentLanguage) {
 								portletTitle.html(cruft);
 
-								var portletTitleText = portletTitle.one('.portlet-title-text');
+								var portletNameText = portletTitle.one('.portlet-name-text');
+								var portletTitleText = instance._curPortlet.one('.portlet-title-text');
 
+								portletNameText.text(value);
 								portletTitleText.text(value);
 							}
 


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-59112.

Please let me know if there are any issues.

Thanks!