### PR TITLE
LPS-53365 - Tooltip messages are sometimes away from their Tip icons

### DIFF
--- a/modules/frontend/frontend-js-web/src/META-INF/resources/liferay/portal.js
+++ b/modules/frontend/frontend-js-web/src/META-INF/resources/liferay/portal.js
@@ -120,6 +120,8 @@
 					}
 				).render();
 
+				cached.after('visibleChange', A.bind('_syncUIPosAlign', cached));
+
 				instance._cached = cached;
 			}
 

--- a/modules/frontend/frontend-js-web/src/META-INF/resources/liferay/portal.js
+++ b/modules/frontend/frontend-js-web/src/META-INF/resources/liferay/portal.js
@@ -133,13 +133,8 @@
 				text = instance._getText(obj.guid());
 			}
 
-			var prevTrigger = cached.get(TRIGGER);
-
-			if (!prevTrigger || !prevTrigger.compareTo(obj)) {
-				cached.set(TRIGGER, obj);
-			}
-
 			cached.set(BODY_CONTENT, text);
+			cached.set(TRIGGER, obj);
 
 			obj.detach('hover');
 


### PR DESCRIPTION
Hey Jon,

Attached is another update for https://issues.liferay.com/browse/LPS-53365.

I reverted my old fix for this issue, since it didn't completely resolve the problem when there were multiple tool tips on the page.  The new fix should resync the alignment every time a tooltip is made visible, and seems to be a better fix for all situations.

Please let me know if there are any issues.

Thanks!