### PR TITLE
LPS-58152 - After adding a page with no name, the page refocuses incorrectly and hides behind the product menu

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,15 +1,17 @@
 @import "mixins";
 
 body {
-	&.open {
+	&.open #wrapper {
 		@include sm() {
 			padding-left: 320px;
 		}
 	}
 
 	&.open, &.sidenav-transition {
-		@include sm() {
-			overflow-x: hidden;
+		#wrapper {
+			@include sm() {
+				overflow-x: hidden;
+			}
 		}
 	}
 }

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/control_menu/product_menu_control_menu_entry.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/control_menu/product_menu_control_menu_entry.jsp
@@ -21,7 +21,7 @@ String productMenuState = SessionClicks.get(request, "com.liferay.control.menu.w
 %>
 
 <li class="<%= Validator.equals(productMenuState, "open") ? "active" : StringPool.BLANK %>">
-	<a class="control-menu-icon sidenav-toggler" data-content="body" data-toggle="sidenav" data-type="fixed-push" data-type-mobile="fixed" href="#sidenavSliderId" id="sidenavToggleId">
+	<a class="control-menu-icon sidenav-toggler" data-content="body" data-target="#sidenavSliderId,#wrapper" data-toggle="sidenav" data-type="fixed-push" data-type-mobile="fixed" href="#sidenavSliderId" id="sidenavToggleId">
 		<span class="icon-align-justify icon-monospaced"></span>
 	</a>
 </li>

--- a/modules/frontend/frontend-theme/frontend-theme-admin-web/src/main/resources/META-INF/resources/admin/_diffs/templates/portlet.vm
+++ b/modules/frontend/frontend-theme/frontend-theme-admin-web/src/main/resources/META-INF/resources/admin/_diffs/templates/portlet.vm
@@ -15,7 +15,7 @@
 		<div class="container-fluid-1280">
 			<div class="toolbar-group">
 				<div class="toolbar-group-content">
-					<a class="sidenav-toggler" data-content="body" data-toggle="sidenav" data-type="fixed-push" data-type-mobile="fixed" data-use-delegate="true" href="#sidenavSliderId" id="sidenavToggleId"><span class="icon-align-justify icon-monospaced"></span></a>
+					<a class="sidenav-toggler" data-content="body" data-target="#sidenavSliderId,#wrapper" data-toggle="sidenav" data-type="fixed-push" data-type-mobile="fixed" data-use-delegate="true" href="#sidenavSliderId" id="sidenavToggleId"><span class="icon-align-justify icon-monospaced"></span></a>
 				</div>
 
 				#if ($portlet_display.isShowBackIcon())


### PR DESCRIPTION
Hey Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-58152.

This was a really frustrating bug for IE 10 & 11.  What I've found is, when trying to submit a form with invalid fields, the aui-form-validator is focusing on this first invalid field it finds using the scrollIntoView method (https://github.com/liferay/alloy-ui/blob/master/src/aui-form-validator/js/aui-form-validator.js#L665).  It seems like IE10 and IE11 is unable to account for styles on the body element when calculating the scroll position, which ends up causing the field to be behind the product menu.

I tried to create a test case outside of portal demonstrating the issue, but was unable to reproduce it.  Which makes me think there is probably something else at play here that I'm overlooking and is causing this issue.

So my fix was to add the padding to the #wrapper div instead of the body element.  Which fixes the issue and doesn't seem to cause any other problems.  But I'm a little afraid the underlying cause of the bug is still there.

Please let me know if there are any issues.

Thanks!