### PR TITLE
LPS-60455 - Apply Lexicon to ui:form-navigator taglib

### DIFF
--- a/modules/frontend/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_form_navigator.scss
+++ b/modules/frontend/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_form_navigator.scss
@@ -1,4 +1,8 @@
 .taglib-form-navigator {
+	ul.form-navigator.list-group {
+		padding-right: 0;
+	}
+
 	> .form-steps > ul.form-navigator.list-group {
 		background: transparent;
 


### PR DESCRIPTION
Hey Jon,

This is an update for https://issues.liferay.com/browse/LPS-60455.

The form navigator just needed to have some inherited padding removed to be fully inline with the lexicon list-group style.

Please let me know if there are any issues.

Thanks!