### PR TITLE
LPS-60537 - Apply Lexicon pattern to ui:toggle taglib

### DIFF
--- a/portal-web/docroot/html/taglib/ui/toggle/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/toggle/page.jsp
@@ -33,13 +33,15 @@ String defaultMessage = (String)request.getAttribute("liferay-ui:toggle:defaultM
 		<a href="javascript:<%= stateVar %>Toggle();" id="<%= id %>_message"><%= defaultMessage %></a>
 	</c:when>
 	<c:otherwise>
-		<img
-			alt='<liferay-ui:message escapeAttribute="<%= true %>" key="toggle" />'
-			id="<%= id %>_image"
-			onclick="<%= stateVar %>Toggle();"
-			src="<%= defaultImage %>"
-			style="margin: 0px;"
-		/>
+		<div class="form-group" id="<%= id %>_image" title='<liferay-ui:message escapeAttribute="<%= true %>" key="toggle" />'>
+			<label>
+				<input class="toggle-switch" onclick="<%= stateVar %>Toggle();" type="checkbox">
+
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle"></span>
+				</span>
+			</label>
+		</div>
 	</c:otherwise>
 </c:choose>
 


### PR DESCRIPTION
Hey Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-60537.

There aren't many places in portal where these changes will actually effect anything. Because we are usually using this taglib with the 'showMessage' instead of the image.  The only place I could find was in the message boards 'combination' view.

Please let me know if there are any issues.

Thanks!