### PR TITLE
LPS-60543 - Apply Lexicon pattern to aui:fieldset taglib

### DIFF
--- a/portal-web/docroot/html/taglib/aui/fieldset/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset/start.jsp
@@ -29,4 +29,4 @@
 		</legend>
 	</c:if>
 
-	<div class="<%= column ? "row-fluid" : StringPool.BLANK %>">
+	<div class="<%= column ? "row" : StringPool.BLANK %>">


### PR DESCRIPTION
Hey Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-60543.

This change isn't exactly lexicon related but I thought it would still be valid to include with these tasks.  I think the `row-fluid` class is leftover from bootstrap 2, and is now should just be `row`.

Please let me know if there are any issues.

Thanks!