### PR TITLE
LPS-61436 Migrate portlet:preview taglib to site-navigation module

### DIFF
--- a/modules/apps/site-navigation/site-navigation-breadcrumb-web/build.gradle
+++ b/modules/apps/site-navigation/site-navigation-breadcrumb-web/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compile project(":apps:configuration-admin:configuration-admin-api")
 	compile project(":apps:dynamic-data-mapping:dynamic-data-mapping-taglib")
 	compile project(":apps:portlet-display-template:portlet-display-template")
+	compile project(":apps:site-navigation:site-navigation-taglib")
 }
 
 liferay {

--- a/modules/apps/site-navigation/site-navigation-breadcrumb-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-breadcrumb-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -56,7 +56,7 @@
 		</aui:form>
 	</aui:col>
 	<aui:col width="<%= 50 %>">
-		<liferay-portlet:preview
+		<liferay-site-navigation:preview
 			portletName="<%= siteNavigationBreadcrumbDisplayContext.getPortletResource() %>"
 			showBorders="<%= true %>"
 		/>

--- a/modules/apps/site-navigation/site-navigation-breadcrumb-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site-navigation/site-navigation-breadcrumb-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/ddm" prefix="liferay-ddm" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
+taglib uri="http://liferay.com/tld/site-navigation" prefix="liferay-site-navigation" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 

--- a/modules/apps/site-navigation/site-navigation-directory-web/build.gradle
+++ b/modules/apps/site-navigation/site-navigation-directory-web/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compile group: "javax.servlet.jsp", name: "jsp-api", version: "2.1"
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
 	compile project(":apps:configuration-admin:configuration-admin-api")
+	compile project(":apps:site-navigation:site-navigation-taglib")
 	compile project(":portal:portal-upgrade")
 }
 

--- a/modules/apps/site-navigation/site-navigation-directory-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-directory-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -48,7 +48,7 @@
 		</aui:form>
 	</aui:col>
 	<aui:col width="<%= 50 %>">
-		<liferay-portlet:preview
+		<liferay-site-navigation:preview
 			portletName="<%= portletResource %>"
 			queryString="struts_action=/sites_directory/view"
 			showBorders="<%= true %>"

--- a/modules/apps/site-navigation/site-navigation-directory-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site-navigation/site-navigation-directory-web/src/main/resources/META-INF/resources/init.jsp
@@ -18,6 +18,7 @@
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
+taglib uri="http://liferay.com/tld/site-navigation" prefix="liferay-site-navigation" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -106,7 +106,7 @@ String rootLayoutType = siteNavigationMenuDisplayContext.getRootLayoutType();
 			</aui:fieldset-group>
 		</aui:col>
 		<aui:col width="<%= 50 %>">
-			<liferay-portlet:preview
+			<liferay-site-navigation:preview
 				portletName="<%= portletResource %>"
 				showBorders="<%= true %>"
 			/>

--- a/modules/apps/site-navigation/site-navigation-site-map-web/build.gradle
+++ b/modules/apps/site-navigation/site-navigation-site-map-web/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compile project(":apps:configuration-admin:configuration-admin-api")
 	compile project(":apps:dynamic-data-mapping:dynamic-data-mapping-taglib")
 	compile project(":apps:portlet-display-template:portlet-display-template")
+	compile project(":apps:site-navigation:site-navigation-taglib")
 	compile project(":portal:portal-upgrade")
 }
 

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/PreviewTag.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/PreviewTag.java
@@ -48,12 +48,12 @@ public class PreviewTag extends IncludeTag {
 		throws Exception {
 
 		request.setAttribute(
-			"liferay-portlet:preview:portletName", portletName);
+			"liferay-site-navigation:preview:portletName", portletName);
 		request.setAttribute(
-			"liferay-portlet:preview:queryString", queryString);
+			"liferay-site-navigation:preview:queryString", queryString);
 		request.setAttribute(
-			"liferay-portlet:preview:showBorders", String.valueOf(showBorders));
-		request.setAttribute("liferay-portlet:preview:width", width);
+			"liferay-site-navigation:preview:showBorders", String.valueOf(showBorders));
+		request.setAttribute("liferay-site-navigation:preview:width", width);
 
 		RequestDispatcher requestDispatcher =
 			servletContext.getRequestDispatcher(page);

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/PreviewTag.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/PreviewTag.java
@@ -95,7 +95,7 @@ public class PreviewTag extends IncludeTag {
 		return _PAGE;
 	}
 
-	private static final String _PAGE = "/html/taglib/portlet/preview/page.jsp";
+	private static final String _PAGE = "/preview/page.jsp";
 
 	private String _portletName;
 	private String _queryString;

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/PreviewTag.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/PreviewTag.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.taglib.portletext;
+package com.liferay.site.navigation.taglib.servlet.taglib;
 
 import com.liferay.taglib.servlet.PipingServletResponse;
 import com.liferay.taglib.util.IncludeTag;

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/PreviewTag.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/PreviewTag.java
@@ -14,6 +14,7 @@
 
 package com.liferay.site.navigation.taglib.servlet.taglib;
 
+import com.liferay.site.navigation.taglib.servlet.ServletContextUtil;
 import com.liferay.taglib.servlet.PipingServletResponse;
 import com.liferay.taglib.util.IncludeTag;
 
@@ -22,6 +23,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.PageContext;
 
 /**
  * @author Brian Wing Shun Chan
@@ -72,6 +74,13 @@ public class PreviewTag extends IncludeTag {
 		catch (Exception e) {
 			throw new JspException(e);
 		}
+	}
+
+	@Override
+	public void setPageContext(PageContext pageContext) {
+		super.setPageContext(pageContext);
+
+		servletContext = ServletContextUtil.getServletContext();
 	}
 
 	public void setPortletName(String portletName) {

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/PreviewTag.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/PreviewTag.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.taglib.portletext;
+
+import com.liferay.taglib.servlet.PipingServletResponse;
+import com.liferay.taglib.util.IncludeTag;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.jsp.JspException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class PreviewTag extends IncludeTag {
+
+	public static void doTag(
+			String portletName, String queryString, boolean showBorders,
+			String width, ServletContext servletContext,
+			HttpServletRequest request, HttpServletResponse response)
+		throws Exception {
+
+		doTag(
+			_PAGE, portletName, queryString, showBorders, width, servletContext,
+			request, response);
+	}
+
+	public static void doTag(
+			String page, String portletName, String queryString,
+			boolean showBorders, String width, ServletContext servletContext,
+			HttpServletRequest request, HttpServletResponse response)
+		throws Exception {
+
+		request.setAttribute(
+			"liferay-portlet:preview:portletName", portletName);
+		request.setAttribute(
+			"liferay-portlet:preview:queryString", queryString);
+		request.setAttribute(
+			"liferay-portlet:preview:showBorders", String.valueOf(showBorders));
+		request.setAttribute("liferay-portlet:preview:width", width);
+
+		RequestDispatcher requestDispatcher =
+			servletContext.getRequestDispatcher(page);
+
+		requestDispatcher.include(request, response);
+	}
+
+	@Override
+	public int doEndTag() throws JspException {
+		try {
+			doTag(
+				getPage(), _portletName, _queryString, _showBorders, _width,
+				servletContext, request,
+				new PipingServletResponse(pageContext));
+
+			return EVAL_PAGE;
+		}
+		catch (Exception e) {
+			throw new JspException(e);
+		}
+	}
+
+	public void setPortletName(String portletName) {
+		_portletName = portletName;
+	}
+
+	public void setQueryString(String queryString) {
+		_queryString = queryString;
+	}
+
+	public void setShowBorders(boolean showBorders) {
+		_showBorders = showBorders;
+	}
+
+	public void setWidth(String width) {
+		_width = width;
+	}
+
+	@Override
+	protected String getPage() {
+		return _PAGE;
+	}
+
+	private static final String _PAGE = "/html/taglib/portlet/preview/page.jsp";
+
+	private String _portletName;
+	private String _queryString;
+	private boolean _showBorders;
+	private String _width;
+
+}

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -14,8 +14,20 @@
  */
 --%>
 
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+
 <%@ page import="com.liferay.portal.kernel.portletdisplaytemplate.PortletDisplayTemplateManagerUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
+page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
+page import="com.liferay.portal.kernel.util.StringPool" %><%@
+page import="com.liferay.portal.kernel.util.StringUtil" %><%@
+page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.util.PortalUtil" %>
 
 <%@ page import="java.util.HashMap" %><%@

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/liferay-site-navigation.tld
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/liferay-site-navigation.tld
@@ -49,4 +49,29 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 	</tag>
+	<tag>
+		<name>preview</name>
+		<tag-class>com.liferay.site.navigation.taglib.servlet.taglib.PreviewTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<name>portletName</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>queryString</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>showBorders</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>width</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
 </taglib>

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/preview/page.jsp
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/preview/page.jsp
@@ -1,0 +1,53 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/html/taglib/init.jsp" %>
+
+<%
+String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_portlet_preview_page") + StringPool.UNDERLINE;
+
+String portletResource = (String)request.getAttribute("liferay-portlet:preview:portletName");
+String queryString = (String)request.getAttribute("liferay-portlet:preview:queryString");
+boolean showBorders = GetterUtil.getBoolean((String)request.getAttribute("liferay-portlet:preview:showBorders"));
+String width = (String)request.getAttribute("liferay-portlet:preview:width");
+
+String previewWidth = ParamUtil.getString(request, "previewWidth");
+
+if (Validator.isNull(width)) {
+	previewWidth = width;
+}
+%>
+
+<div class="taglib-portlet-preview <%= showBorders ? "show-borders" : StringPool.BLANK %>">
+	<c:if test="<%= showBorders %>">
+		<div class="title">
+			<liferay-ui:message key="preview" />
+		</div>
+	</c:if>
+
+	<div class="preview" id="<%= randomNamespace %>">
+		<div style="margin: 3px; width: <%= Validator.isNotNull(previewWidth) ? ((GetterUtil.getInteger(previewWidth) + 20) + "px") : "100%" %>;">
+			<liferay-portlet:runtime
+				portletName="<%= portletResource %>"
+				queryString="<%= queryString %>"
+			/>
+		</div>
+	</div>
+</div>
+
+<aui:script>
+	Liferay.Util.disableElements('#<%= randomNamespace %>');
+</aui:script>

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/preview/page.jsp
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/preview/page.jsp
@@ -19,10 +19,10 @@
 <%
 String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_portlet_preview_page") + StringPool.UNDERLINE;
 
-String portletResource = (String)request.getAttribute("liferay-portlet:preview:portletName");
-String queryString = (String)request.getAttribute("liferay-portlet:preview:queryString");
-boolean showBorders = GetterUtil.getBoolean((String)request.getAttribute("liferay-portlet:preview:showBorders"));
-String width = (String)request.getAttribute("liferay-portlet:preview:width");
+String portletResource = (String)request.getAttribute("liferay-site-navigation:preview:portletName");
+String queryString = (String)request.getAttribute("liferay-site-navigation:preview:queryString");
+boolean showBorders = GetterUtil.getBoolean((String)request.getAttribute("liferay-site-navigation:preview:showBorders"));
+String width = (String)request.getAttribute("liferay-site-navigation:preview:width");
 
 String previewWidth = ParamUtil.getString(request, "previewWidth");
 

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/preview/page.jsp
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/preview/page.jsp
@@ -14,7 +14,7 @@
  */
 --%>
 
-<%@ include file="/html/taglib/init.jsp" %>
+<%@ include file="/init.jsp" %>
 
 <%
 String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_portlet_preview_page") + StringPool.UNDERLINE;

--- a/readme/7.0/BREAKING_CHANGES.markdown
+++ b/readme/7.0/BREAKING_CHANGES.markdown
@@ -3196,3 +3196,28 @@ This change was made as a part of the ongoing strategy to modularize Liferay
 Portal by means of an OSGi container.
 
 ---------------------------------------
+
+### The liferay-portlet:preview taglib has been deprecated and replaced with liferay-site-navigation:preview taglib
+- **Date:** 2015-Dec-17
+- **JIRA Ticket:** LPS-61436
+
+#### What changed?
+
+The `liferay-portlet:preview` taglib has been deprecated and replaced with
+`liferay-site-navigation:preview` taglib.
+
+#### Who is affected?
+
+Plugins or templates that are using the `liferay-portlet:preview` tag need
+to update their usage of the tag.
+
+#### How should I update my code?
+
+You should import the `liferay-site-navigation` tag library if it isn't already
+and update the tag namespace from `liferay-portlet:preview` to
+`liferay-site-navigation:preview`.
+
+#### Why was this change made?
+
+This change was made as a part of the ongoing strategy to modularize Liferay
+Portal by means of an OSGi container.

--- a/util-taglib/src/META-INF/liferay-portlet-ext.tld
+++ b/util-taglib/src/META-INF/liferay-portlet-ext.tld
@@ -185,6 +185,7 @@
 		</attribute>
 	</tag>
 	<tag>
+		<description>Deprecated as of 7.0.0, replaced by <![CDATA[<code>liferay-site-navigation:preview</code>]]>.</description>
 		<name>preview</name>
 		<tag-class>com.liferay.taglib.portletext.PreviewTag</tag-class>
 		<body-content>JSP</body-content>

--- a/util-taglib/src/com/liferay/taglib/portletext/PreviewTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/PreviewTag.java
@@ -25,7 +25,11 @@ import javax.servlet.jsp.JspException;
 
 /**
  * @author Brian Wing Shun Chan
+ * @deprecated As of 7.0.0, replaced by {@link
+ *             com.liferay.site.navigation.taglib.servlet.taglib.
+ *             PreviewTag}
  */
+@Deprecated
 public class PreviewTag extends IncludeTag {
 
 	public static void doTag(


### PR DESCRIPTION
Hi Jon!

Attached is an update for https://issues.liferay.com/browse/LPS-61436. Added gradle dependencies for modules using the preview taglib. There doesn't seem to be any js modules required for this taglib.

Let me know if there are any issues. Thanks!