### PR TITLE
LPS-62430 Browse label name display as "null" in certain navbar menus

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/toolbar.jsp
+++ b/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/toolbar.jsp
@@ -17,8 +17,6 @@
 <%@ include file="/init.jsp" %>
 
 <%
-String toolbarItem = ParamUtil.getString(request, "toolbarItem", "browse");
-
 long groupId = ParamUtil.getLong(request, "groupId", themeDisplay.getScopeGroupId());
 
 if (groupId == 0) {
@@ -32,8 +30,6 @@ PortletURL portletURL = (PortletURL)request.getAttribute("view.jsp-portletURL");
 
 AssetRendererFactory<?> assetRendererFactory = AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(typeSelection);
 %>
-
-<aui:nav-item href="<%= portletURL %>" label="browse" selected='<%= toolbarItem.equals("browse") %>' />
 
 <c:choose>
 	<c:when test="<%= assetRendererFactory.isSupportsClassTypes() && (subtypeSelectionId > 0) %>">

--- a/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -24,6 +24,7 @@ String typeSelection = ParamUtil.getString(request, "typeSelection");
 long subtypeSelectionId = ParamUtil.getLong(request, "subtypeSelectionId");
 boolean showNonindexable = ParamUtil.getBoolean(request, "showNonindexable");
 boolean showScheduled = ParamUtil.getBoolean(request, "showScheduled");
+String toolbarItem = ParamUtil.getString(request, "toolbarItem", "browse");
 
 Boolean listable = null;
 
@@ -95,6 +96,8 @@ else {
 
 <aui:nav-bar cssClass="collapse-basic-search" markupView="lexicon">
 	<aui:nav cssClass="navbar-nav" searchContainer="<%= assetBrowserSearch %>">
+		<aui:nav-item href="<%= portletURL %>" label="browse" selected='<%= toolbarItem.equals("browse") %>' />
+
 		<liferay-util:include page="/toolbar.jsp" servletContext="<%= application %>">
 			<liferay-util:param name="groupId" value="<%= String.valueOf(groupId) %>" />
 			<liferay-util:param name="typeSelection" value="<%= typeSelection %>" />


### PR DESCRIPTION
Hi @jonmak08,

Attached is an update for: https://issues.liferay.com/browse/LPS-62430

This issue occurs since the `selectedItemName` variable in the `aui:nav-bar` taglib isn't getting set when the `aui:nav-item` tag is in a separate file being included through the `liferay-util:include` tag.

Let me know if there are any issues. Thanks!