### PR TITLE
LPS-62427 While creating Aui popup, width/height auto doesn't work.

### DIFF
--- a/modules/frontend/frontend-js-web/src/main/resources/META-INF/resources/liferay/util_window.js
+++ b/modules/frontend/frontend-js-web/src/main/resources/META-INF/resources/liferay/util_window.js
@@ -379,11 +379,11 @@ AUI.add(
 					var height = modalConfig.height;
 					var width = modalConfig.width;
 
-					if (height === '' || height === undefined || height > DOM.winHeight()) {
+					if (height === 'auto' || height === '' || height === undefined || height > DOM.winHeight()) {
 						modalConfig.autoHeight = true;
 					}
 
-					if (width === '' || width === undefined || width > DOM.winWidth()) {
+					if (width === 'auto' || width === '' || width === undefined || width > DOM.winWidth()) {
 						modalConfig.autoWidth = true;
 					}
 

--- a/modules/frontend/frontend-js-web/src/main/resources/META-INF/resources/liferay/util_window.js
+++ b/modules/frontend/frontend-js-web/src/main/resources/META-INF/resources/liferay/util_window.js
@@ -420,11 +420,22 @@ AUI.add(
 
 						height *= modal.get('autoHeightRatio');
 
-						modal.set('height', height);
+						if (modal.get('height') === 'auto') {
+							modal._fillMaxHeight(height);
+						}
+						else {
+							modal.set('height', height);
+						}
 					}
 
 					if (modal.get('autoWidth')) {
 						var width;
+
+						var widthInitial = modal.get('width');
+
+						if (widthInitial === 'auto') {
+							return;
+						}
 
 						if (autoSizeNode) {
 							width = autoSizeNode.get('offsetWidth');
@@ -434,8 +445,6 @@ AUI.add(
 						}
 
 						width *= modal.get('autoWidthRatio');
-
-						var widthInitial = modal.get('width');
 
 						if (width != widthInitial) {
 							modal.set('width', width);


### PR DESCRIPTION
Hey Jon

Happy Chinese new year, :)

Days ago, I sent a solution for LPS-62427 to you https://github.com/natecavanaugh/liferay-portal/pull/3783.

However, that solution still left some problem.

First of all, we need to set max-height for the modal so that its content can be rendered properly when it exceed the window.

Then, even if with this fix, it does not work properly in Trunk because we have to remove ``right:0`` in https://github.com/liferay/lexicon/blame/master/src/scss/bootstrap/_modals.scss#L21,

Or we need to override the right somewhere to make the modal's width initialized according to its content when its width is set ``auto``.

We only need to do this in Trunk. 6,2,x only has the issue about max-height.

I am not sure if we need remove it in lexicon or we still need support this feature in Trunk?

/cc @daledotshan, @natecavanaugh

Thanks
John.