### PR TITLE
Lps 59911 alloy add button

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -281,6 +281,12 @@
 	#blogsCommentsPanelContainer {
 		border-width: 0;
 	}
+
+	.cke_focus[data-placeholder='Content'] {
+		@include respond-to(phone, tablet) {
+			margin-left: 50px;
+		}
+	}
 }
 
 .firefox .portlet-blogs fieldset.input-container {


### PR DESCRIPTION
Hey Jon, please check the PR!

For the fix, I decided to shrink the size of the input width so as to make room for the button when the browser's input box fills up 100% width of the screen.  When the input box doesn't fill up 100%, the add button looks great and there needs to be no shrinking.  The reason for this fix is as follows...

It appears that a fundamental part of AlloyEditor is that it's "add button" appears directly to the left of the input element.  Even on their webpage, if the browser is too small (e.g. if it is on a mobile screen), the button will not show.  Either the fix is to change something inherently within AlloyEditor's design or to fix every tablet/mobile friendly page to incorporate a fix (e.g. margin-left) for AlloyEditor's add button.

Thanks,
Tyler