### PR TITLE
LPS-63202 - Ellipsis icons do not display in IE11

### DIFF
--- a/portal-web/docroot/html/taglib/aui/icon/lexicon/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/icon/lexicon/page.jsp
@@ -40,11 +40,20 @@
 </c:choose>
 
 <liferay-util:html-bottom outputKey="taglib_aui_icon_lexicon">
-	<aui:script>
-		svg4everybody(
-			{
-				polyfill: true
-			}
-		);
+	<aui:script use="aui-base">
+		<c:if test="<%= BrowserSnifferUtil.isIe(request) %>">
+			A.after(
+				'domready',
+				function() {
+		</c:if>
+					svg4everybody(
+						{
+							polyfill: true
+						}
+					);
+		<c:if test="<%= BrowserSnifferUtil.isIe(request) %>">
+				}
+			);
+		</c:if>
 	</aui:script>
 </liferay-util:html-bottom>


### PR DESCRIPTION
Hey Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-63202.

This is a potential workaround for this issue in IE.  It seems the the crystal-dropdown is mutating the dom while svg4everybody is running, causing svg icons to end up not being rendered in dropdowns.

Please let me know if there are any issues.

Thanks!