### PR TITLE
LPS-57867 Focus on search text box when panel is expanded

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamic Data Mapping Service
 small.image.extensions.description=Set the allowed file extensions for template images. A file extension of * will permit all file extensions.
 small.image.max.size.description=Set the maximum file size for template images in bytes. A value of 0 can be used to indicate unlimited file size.
-there-are-no-templates=There are no templates.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_ar.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=خدمة خرائط البيانات الديناميكية (Automatic Translation)
 small.image.extensions.description=تعيين ملحقات الملفات المسموح بها لصور القالب. ملحق ملف * سوف تسمح كافة ملحقات الملفات. (Automatic Translation)
 small.image.max.size.description=تعيين الحجم الأقصى للملف للصور القالب بالبايت. يمكن استخدام قيمة 0 للإشارة إلى حجم الملف غير محدود. (Automatic Translation)
-there-are-no-templates=لا توجد قوالب.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_bg.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Динамични данни картографска услуга (Automatic Translation)
 small.image.extensions.description=Задайте позволено файлови разширения за шаблон изображения. Файлово разширение на * ще позволи всички файлови разширения. (Automatic Translation)
 small.image.max.size.description=Задайте максималния размер на файла за шаблон изображения в байтове. Стойност 0 може да се използва за указване unlimited пила размер. (Automatic Translation)
-there-are-no-templates=Няма шаблони.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_ca.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Servei de mapatge de dades dinàmiques (Automatic Translation)
 small.image.extensions.description=Establir les extensions de fitxer permesos per a imatges de plantilla. Una extensió d'arxiu * permetrà totes les ampliacions d'arxiu. (Automatic Translation)
 small.image.max.size.description=Establir la mida màxima del fitxer per a imatges de plantilla en bytes. Un valor de 0 pot ser emprat per indicar la mida d'arxiu il·limitat. (Automatic Translation)
-there-are-no-templates=No hi ha cap plantilla.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_cs.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamická Data mapová služba (Automatic Translation)
 small.image.extensions.description=Nastavení povolené přípony pro šablony snímků. Příponu souboru * umožní všechny přípony souborů. (Automatic Translation)
 small.image.max.size.description=Nastavte maximální velikost souboru pro šablony obrazy v bajtech. Hodnota 0 lze použít k označení neomezenou velikost souboru. (Automatic Translation)
-there-are-no-templates=Nebyly nalezeny žádné šablony.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_da.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_da.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamic Data kortlægningstjeneste (Automatic Translation)
 small.image.extensions.description=Angive de tilladte filtypenavne for skabelon billeder. En fil forlængelse af * vil tillade alle filtypenavne. (Automatic Translation)
 small.image.max.size.description=Angiv den maksimale filstørrelse for skabelon billeder i byte. En værdi på 0 kan bruges til at angive Ubegrænset filstørrelse. (Automatic Translation)
-there-are-no-templates=Der er ingen skabeloner.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_de.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_de.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamic Data Mapping Service
 small.image.extensions.description=Geben Sie die erlaubten Dateierweiterungen für Vorlagenbilder an. Die Angabe von * erlaubt alle Dateierweiterungen.
 small.image.max.size.description=Geben Sie die maximale Dateigröße für Vorlagenbilder an. Der Wert 0 kann verwendet werden, um beliebig große Dateien zu erlauben.
-there-are-no-templates=Keine Vorlagen verfügbar.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_el.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_el.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Δυναμικά δεδομένα υπηρεσία χαρτογράφησης (Automatic Translation)
 small.image.extensions.description=Ορίστε τις επιτρεπόμενες επεκτάσεις για πρότυπο εικόνες. Επέκταση αρχείου * θα επιτρέψει όλες τις επεκτάσεις αρχείων. (Automatic Translation)
 small.image.max.size.description=Ορίστε το μέγιστο μέγεθος αρχείου για το πρότυπο εικόνες σε byte. Η τιμή 0 μπορεί να χρησιμοποιηθεί για να υποδείξετε απεριόριστος αρχείο μέγεθος. (Automatic Translation)
-there-are-no-templates=Δεν υπάρχει κανένα πρότυπο.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_en.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_en.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamic Data Mapping Service
 small.image.extensions.description=Set the allowed file extensions for template images. A file extension of * will permit all file extensions.
 small.image.max.size.description=Set the maximum file size for template images in bytes. A value of 0 can be used to indicate unlimited file size.
-there-are-no-templates=There are no templates.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_es.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_es.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Servicio de mapas de datos dinámicos (Automatic Translation)
 small.image.extensions.description=Configurar las extensiones de archivo permitido para las imágenes de la plantilla. Una extensión de archivo * permitirá que todas las extensiones de archivo. (Automatic Translation)
 small.image.max.size.description=Establecer el tamaño máximo de archivo para imágenes de la plantilla en bytes. Puede utilizar un valor de 0 para indicar el tamaño de archivo ilimitado. (Automatic Translation)
-there-are-no-templates=No hay plantillas.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_et.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_et.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dünaamilise kaardistamine teenus (Automatic Translation)
 small.image.extensions.description=Saate malli pilte lubatud failitüüpide laiendid. Faililaiend on * võimaldab kõiki faililaiendeid. (Automatic Translation)
 small.image.max.size.description=Määra malli piltide suurima mahu baitides. Väärtus 0 saab kasutada näitamaks piiramatu faili suurus. (Automatic Translation)
-there-are-no-templates=Malle ei ole.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_eu.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamic Data Mapping Service (Automatic Copy)
 small.image.extensions.description=Set the allowed file extensions for template images. A file extension of * will permit all file extensions. (Automatic Copy)
 small.image.max.size.description=Set the maximum file size for template images in bytes. A value of 0 can be used to indicate unlimited file size. (Automatic Copy)
-there-are-no-templates=Ez dago txantiloirik.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_fa.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=خدمات نقشه برداری داده های پویا (Automatic Translation)
 small.image.extensions.description=تعیین پسوند های مجاز فایل برای تصاویر الگو. پسوند از * همه پسوند فایل را نیز می دهند. (Automatic Translation)
 small.image.max.size.description=تنظیم اندازه پرونده حداکثر برای تصاویر الگو در کلمه در ادامه متن. مقدار 0 می تواند مورد استفاده قرار گیرد به اندازه پرونده نامحدود را نشان می دهد. (Automatic Translation)
-there-are-no-templates=قالبی وجود ندارد

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_fi.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamic Data karttapalvelu (Automatic Translation)
 small.image.extensions.description=Määritä sallittujen tiedostotyyppien tunnisteet malli kuvia. Tiedostotunniste on * mahdollistavat kaikki tiedostotarkenteet. (Automatic Translation)
 small.image.max.size.description=Määrittää mallin kuvia tiedoston enimmäiskoko tavuina. Arvo 0 voidaan ilmoittaa rajaton arkistoida koko. (Automatic Translation)
-there-are-no-templates=Esitysmalleja ei löydy.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_fr.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Service de cartographie de données dynamiques (Automatic Translation)
 small.image.extensions.description=Définissez les extensions de fichiers autorisées pour les images de modèle. Extension de fichier * permettra à toutes les extensions de fichier. (Automatic Translation)
 small.image.max.size.description=Définir la taille de fichier maximale pour les images de modèle en octets. Une valeur 0 peut être utilisée pour indiquer la taille de fichier. (Automatic Translation)
-there-are-no-templates=Il n'y a aucun modèle de document.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_gl.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamic Data Mapping Service (Automatic Copy)
 small.image.extensions.description=Set the allowed file extensions for template images. A file extension of * will permit all file extensions. (Automatic Copy)
 small.image.max.size.description=Set the maximum file size for template images in bytes. A value of 0 can be used to indicate unlimited file size. (Automatic Copy)
-there-are-no-templates=Non hai modelos.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_hi_IN.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=गतिशील डेटा मानचित्रण सेवा (Automatic Translation)
 small.image.extensions.description=अनुमति फ़ाइल एक्सटेंशन है टेम्पलेट छवियों के लिए सेट करें। किसी फ़ाइल एक्सटेंशन के * सभी फ़ाइल एक्सटेंशनों की अनुमति देगा। (Automatic Translation)
 small.image.max.size.description=टेम्पलेट छवियों के लिए अधिकतम फ़ाइल आकार बाइट्स में सेट करें। 0 का कोई मान असीमित फ़ाइल आकार इंगित करने के लिए इस्तेमाल किया जा सकता। (Automatic Translation)
-there-are-no-templates=कोई templates नही है|

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_hr.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamic Data Mapping Service (Automatic Copy)
 small.image.extensions.description=Set the allowed file extensions for template images. A file extension of * will permit all file extensions. (Automatic Copy)
 small.image.max.size.description=Set the maximum file size for template images in bytes. A value of 0 can be used to indicate unlimited file size. (Automatic Copy)
-there-are-no-templates=Nema templates.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_hu.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamic Data térképészeti szolgáltatás (Automatic Translation)
 small.image.extensions.description=Állítsa be a sablon képeket engedélyezett fájlnév-kiterjesztéseket. A fájl kiterjesztése * lehetővé teszi a fájlnevek kiterjesztését. (Automatic Translation)
 small.image.max.size.description=Meghatározott sablon képeket a maximális méretét bájtban. A 0 érték korlátlan fájlméret jelzésére használható. (Automatic Translation)
-there-are-no-templates=Nincsenek sablonok.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_in.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_in.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Layanan pemetaan Data dinamis (Automatic Translation)
 small.image.extensions.description=Mengatur ekstensi file yang diizinkan untuk template gambar. Ekstensi file dari * akan mengizinkan semua ekstensi file. (Automatic Translation)
 small.image.max.size.description=Mengatur ukuran file maksimum untuk template gambar dalam bytes. Nilai 0 dapat digunakan untuk menunjukkan ukuran file tak terbatas. (Automatic Translation)
-there-are-no-templates=Tidak ada template.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_it.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_it.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Servizio di Mapping di dati dinamici (Automatic Translation)
 small.image.extensions.description=Impostare le estensioni di file consentiti per le immagini del modello. Un'estensione di file di * permetterà tutte le estensioni di file. (Automatic Translation)
 small.image.max.size.description=Impostare la dimensione massima dei file per le immagini del modello in byte. Un valore pari a 0 può essere utilizzato per indicare dimensioni file illimitate. (Automatic Translation)
-there-are-no-templates=Non ci sono modelli.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_iw.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=שירות מיפוי נתונים דינמיים (Automatic Translation)
 small.image.extensions.description=להגדיר סיומות הקבצים המותרים עבור תבנית תמונות. סיומת הקובץ * יאפשר כל סיומות הקבצים. (Automatic Translation)
 small.image.max.size.description=קבע את גודל הקובץ המרבי עבור תבנית תמונות בבתים. ערך של 0 יכול לשמש כדי לציין גודל הקובץ ללא הגבלה. (Automatic Translation)
-there-are-no-templates=אין תבניות

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_ja.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=動的データ マッピング サービス (Automatic Translation)
 small.image.extensions.description=テンプレート画像の許可されるファイル拡張子を設定します。ファイルの拡張子は * すべてのファイル拡張子が許可されます。 (Automatic Translation)
 small.image.max.size.description=テンプレート イメージの最大ファイル サイズをバイト単位で設定します。値 0 は、無制限のファイルのサイズを指定する使用できます。 (Automatic Translation)
-there-are-no-templates=テンプレートはありません。

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_ko.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=동적 데이터 매핑 서비스 (Automatic Translation)
 small.image.extensions.description=템플릿 이미지에 대 한 허용된 파일 확장명을 설정 합니다. 파일 확장명은 * 모든 파일 확장명을 허용 한다. (Automatic Translation)
 small.image.max.size.description=바이트에서 템플릿 이미지에 대 한 최대 파일 크기를 설정 합니다. 값이 0 무제한 파일 크기를 나타내는 데 사용할 수 있습니다. (Automatic Translation)
-there-are-no-templates=템플렛.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_lo.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamic Data Mapping Service (Automatic Copy)
 small.image.extensions.description=Set the allowed file extensions for template images. A file extension of * will permit all file extensions. (Automatic Copy)
 small.image.max.size.description=Set the maximum file size for template images in bytes. A value of 0 can be used to indicate unlimited file size. (Automatic Copy)
-there-are-no-templates=ບໍ່ມີແທ໋ມເພຣ໋ດໃດ

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_lt.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dinaminių duomenų atvaizdavimo paslaugos (Automatic Translation)
 small.image.extensions.description=Nustatyti leistinų failų plėtinius šabloną vaizdai. Failo plėtiniu * leis visų failų plėtinius. (Automatic Translation)
 small.image.max.size.description=Nustatyti maksimalų failo dydį šabloną vaizdai baitais. Reikšmė 0 galima nurodyti neribotą failų dydį. (Automatic Translation)
-there-are-no-templates=There are no templates. (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_nb.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Tilordningstjenesten for dynamiske Data (Automatic Translation)
 small.image.extensions.description=Angi de tillatte filtypene for malen bilder. Filtypen * tillater alle filtyper. (Automatic Translation)
 small.image.max.size.description=Angi maksimumsstørrelsen for malen bilder i byte. Verdien 0 kan brukes til å angi ubegrenset filstørrelse. (Automatic Translation)
-there-are-no-templates=Det finnes ingen maler.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_nl.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamische gegevens kaartservice op Internet (Automatic Translation)
 small.image.extensions.description=De toegestane bestandsextensies voor sjabloon afbeeldingen instellen De bestandsextensie * toestaat alle bestandsextensies. (Automatic Translation)
 small.image.max.size.description=Stel de maximale bestandsgrootte voor sjabloon beelden in bytes. Een waarde van 0 kan worden gebruikt om aan te geven van onbeperkte bestandsgrootte. (Automatic Translation)
-there-are-no-templates=Er zijn geen sjablonen.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_nl_BE.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamische gegevens kaartservice op Internet (Automatic Translation)
 small.image.extensions.description=De toegestane bestandsextensies voor sjabloon afbeeldingen instellen De bestandsextensie * toestaat alle bestandsextensies. (Automatic Translation)
 small.image.max.size.description=Stel de maximale bestandsgrootte voor sjabloon beelden in bytes. Een waarde van 0 kan worden gebruikt om aan te geven van onbeperkte bestandsgrootte. (Automatic Translation)
-there-are-no-templates=Er zijn geen templates.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_pl.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Usługa mapowania danych dynamicznych (Automatic Translation)
 small.image.extensions.description=Zestaw dozwolonych rozszerzenia obrazów szablonu. Z rozszerzeniem * pozwoli na wszystkie rozszerzenia plików. (Automatic Translation)
 small.image.max.size.description=Ustaw maksymalny rozmiar pliku dla obrazów szablonu w bajtach. Wartość 0 może służyć do wskazywania nieograniczony rozmiar pliku. (Automatic Translation)
-there-are-no-templates=Brak szablonów.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_pt_BR.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Serviço de mapeamento de dados dinâmicos (Automatic Translation)
 small.image.extensions.description=Defina as extensões de arquivos permitidos para imagens do modelo. Uma extensão de arquivo * permitirá que todas as extensões de arquivo. (Automatic Translation)
 small.image.max.size.description=Defina o tamanho máximo de arquivo para imagens do modelo em bytes. Um valor de 0 pode ser usado para indicar o tamanho de arquivo ilimitado. (Automatic Translation)
-there-are-no-templates=Não há modelos.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_pt_PT.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Serviço de mapeamento de dados dinâmicos (Automatic Translation)
 small.image.extensions.description=Defina as extensões de arquivos permitidos para imagens do modelo. Uma extensão de arquivo * permitirá que todas as extensões de arquivo. (Automatic Translation)
 small.image.max.size.description=Defina o tamanho máximo de arquivo para imagens do modelo em bytes. Um valor de 0 pode ser usado para indicar o tamanho de arquivo ilimitado. (Automatic Translation)
-there-are-no-templates=Não há nenhum molde.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_ro.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Servicii de cartografiere date dinamice (Automatic Translation)
 small.image.extensions.description=Stabilite extensii de fişiere permise pentru imagini de şablon. Un dosar prelungire de * va permite toate extensii. (Automatic Translation)
 small.image.max.size.description=Setaţi dimensiunea maximă de fișier pentru șablonul imagini în octeţi. Valoarea 0 poate fi folosit pentru a indica unlimited dosar size. (Automatic Translation)
-there-are-no-templates=Nu sunt Sabloane.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_ru.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Служба сопоставления динамических данных (Automatic Translation)
 small.image.extensions.description=Задание разрешенных файлов расширений для изображений шаблонов. Расширение файла * будет разрешить все расширения файлов. (Automatic Translation)
 small.image.max.size.description=Установите максимальный размер файла для шаблона изображения в байтах. Значение 0 может использоваться для обозначения неограниченный размер файла. (Automatic Translation)
-there-are-no-templates=Нет шаблонов.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_sk.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamické údaje mapovacej služby (Automatic Translation)
 small.image.extensions.description=Nastaviť povolené prípony pre šablóny snímok. Príponou * umožnia všetky prípony. (Automatic Translation)
 small.image.max.size.description=Nastavená maximálna veľkosť súboru pre obrázky, šablóny v bajtoch. Hodnota 0 možno označovať neobmedzená veľkosť súboru. (Automatic Translation)
-there-are-no-templates=Žiadne šablóny.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_sl.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamic Data kartograf usluga (Automatic Translation)
 small.image.extensions.description=Nastavite dovoljenega pripon za predlogo slike. Pripono * omogočila vse pripone. (Automatic Translation)
 small.image.max.size.description=Nastavite največjo velikost datoteke za predlogo slike v bajtih. Vrednost 0 uporabite za označevanje neomejen pila velikost. (Automatic Translation)
-there-are-no-templates=Ni predlog.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_sr_RS.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamic Data Mapping Service (Automatic Copy)
 small.image.extensions.description=Set the allowed file extensions for template images. A file extension of * will permit all file extensions. (Automatic Copy)
 small.image.max.size.description=Set the maximum file size for template images in bytes. A value of 0 can be used to indicate unlimited file size. (Automatic Copy)
-there-are-no-templates=Нема темплејта.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamic Data Mapping Service (Automatic Copy)
 small.image.extensions.description=Set the allowed file extensions for template images. A file extension of * will permit all file extensions. (Automatic Copy)
 small.image.max.size.description=Set the maximum file size for template images in bytes. A value of 0 can be used to indicate unlimited file size. (Automatic Copy)
-there-are-no-templates=Nema templejta.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_sv.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dynamiska Data kartservice (Automatic Translation)
 small.image.extensions.description=Ange de tillåtna filändelser för mall bilder. En fil förlängning av * tillåter alla filnamnstillägg. (Automatic Translation)
 small.image.max.size.description=Ange den maximala filstorleken för mall bilder i byte. Värdet 0 kan användas för att ange obegränsad filstorlek. (Automatic Translation)
-there-are-no-templates=Det finns inga mallar.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_tr.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dinamik veri eşleme hizmeti (Automatic Translation)
 small.image.extensions.description=İzin verilen dosya uzantıları şablon görüntüler için ayarlayın. Bir dosya uzantısı * tüm dosya uzantılarını izin verir. (Automatic Translation)
 small.image.max.size.description=Şablon görüntüler için en büyük dosya boyutu bayt olarak ayarlayın. 0 değeri, sınırsız dosya boyutu belirtmek için kullanılabilir. (Automatic Translation)
-there-are-no-templates=Şablon yok.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_uk.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Динамічних даних картографічну службу (Automatic Translation)
 small.image.extensions.description=Встановити для шаблону зображень, розширення дозволених файлів. Розширення файлу * дозволить всі розширення імені файлу. (Automatic Translation)
 small.image.max.size.description=Встановити максимальний розмір файлу для шаблону зображень в байтах. Значення 0 може використовуватися для позначення необмежений розмір. (Automatic Translation)
-there-are-no-templates=Нема шаблонів.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_vi.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=Dịch vụ lập bản đồ năng động dữ liệu (Automatic Translation)
 small.image.extensions.description=Thiết lập tiện ích mở rộng cho phép tập tin cho hình ảnh mẫu. Một phần mở rộng tập tin của * sẽ cho phép tất cả các phần mở rộng tệp. (Automatic Translation)
 small.image.max.size.description=Thiết lập kích thước tệp tối đa cho hình ảnh mẫu theo byte. Giá trị 0 có thể được sử dụng để chỉ ra không giới hạn kích thước. (Automatic Translation)
-there-are-no-templates=Chưa có biểu mẫu tùy biến hiển thị nào.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_zh_CN.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=动态数据映射服务 (Automatic Translation)
 small.image.extensions.description=设置允许的文件扩展名的模板图像。文件扩展名为 * 将允许所有的文件扩展名。 (Automatic Translation)
 small.image.max.size.description=设置模板图像的最大文件大小，以字节为单位。值为 0 可以用于指示文件大小无限制。 (Automatic Translation)
-there-are-no-templates=没有模板。

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/content/Language_zh_TW.properties
@@ -1,4 +1,3 @@
 ddm.service.configuration.name=動態資料映射服務 (Automatic Translation)
 small.image.extensions.description=設置允許的檔副檔名的範本圖像。檔副檔名為 * 將允許所有的檔副檔名。 (Automatic Translation)
 small.image.max.size.description=設置範本圖像的最大檔案大小，以位元組為單位。值為 0 可以用於指示檔案大小無限制。 (Automatic Translation)
-there-are-no-templates=沒有版型。

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/add_application.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/add_application.jsp
@@ -177,6 +177,7 @@ refererURL.setParameter("updateLayout", "true");
 	var ControlMenu = Liferay.ControlMenu;
 
 	var searchApplication = A.one('#<portlet:namespace />searchApplication');
+	var applicationPanelBody = A.one('#<portlet:namespace />addApplicationCollapse');
 
 	var addApplication = new ControlMenu.AddApplication(
 		{
@@ -185,6 +186,7 @@ refererURL.setParameter("updateLayout", "true");
 			namespace: '<portlet:namespace />',
 			nodeList: A.one('#<portlet:namespace />applicationList'),
 			nodeSelector: '.drag-content-item',
+			panelBody: applicationPanelBody,
 			selected: !A.one('#<portlet:namespace />addApplicationForm').ancestor().hasClass('hide')
 		}
 	);

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/add_application.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/add_application.jsp
@@ -186,8 +186,7 @@ refererURL.setParameter("updateLayout", "true");
 			namespace: '<portlet:namespace />',
 			nodeList: A.one('#<portlet:namespace />applicationList'),
 			nodeSelector: '.drag-content-item',
-			panelBody: applicationPanelBody,
-			selected: !A.one('#<portlet:namespace />addApplicationForm').ancestor().hasClass('hide')
+			panelBody: applicationPanelBody
 		}
 	);
 

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/add_content.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/add_content.jsp
@@ -57,8 +57,7 @@ String displayStyle = ParamUtil.getString(request, "displayStyle", displayStyleD
 			focusItem: searchContent,
 			inputNode: searchContent,
 			namespace: '<portlet:namespace />',
-			panelBody: contentPanelBody,
-			selected: !A.one('#<portlet:namespace />addContentForm').ancestor().hasClass('hide')
+			panelBody: contentPanelBody
 		}
 	);
 

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/add_content.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/add_content.jsp
@@ -48,6 +48,7 @@ String displayStyle = ParamUtil.getString(request, "displayStyle", displayStyleD
 	var ControlMenu = Liferay.ControlMenu;
 
 	var searchContent = A.one('#<portlet:namespace />searchContent');
+	var contentPanelBody = A.one('#<portlet:namespace />addContentCollapse');
 
 	var addContent = new ControlMenu.AddContent(
 		{
@@ -56,6 +57,7 @@ String displayStyle = ParamUtil.getString(request, "displayStyle", displayStyleD
 			focusItem: searchContent,
 			inputNode: searchContent,
 			namespace: '<portlet:namespace />',
+			panelBody: contentPanelBody,
 			selected: !A.one('#<portlet:namespace />addContentForm').ancestor().hasClass('hide')
 		}
 	);

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
@@ -154,8 +154,6 @@ AUI.add(
 					_bindUIDABase: function() {
 						var instance = this;
 
-						instance._eventHandles.push(Liferay.after('showTab', instance._showTab, instance));
-
 						var panelBody = $('#' + instance._panelBody.get('id'));
 
 						instance._eventHandles.push(panelBody.on('shown.bs.collapse', instance, instance._focusOnItem));
@@ -270,14 +268,6 @@ AUI.add(
 									instance._hideAddedMessageTask();
 								}
 							);
-						}
-					},
-
-					_showTab: function(event) {
-						var instance = this;
-
-						if (instance._focusItem && event.tabSection && event.tabSection.contains(instance._focusItem)) {
-							instance._focusItem.focus();
 						}
 					},
 

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
@@ -61,6 +61,12 @@ AUI.add(
 					initializer: function(config) {
 						var instance = this;
 
+						instance._addedMessage = instance.byId('addedMessage');
+
+						instance._eventHandles = [];
+
+						instance._hideAddedMessageTask = A.debounce(A.bind('_hideAddedMessage', instance), 2000);
+
 						if (instance._isSelected()) {
 							var focusItem = instance.get('focusItem');
 
@@ -68,12 +74,6 @@ AUI.add(
 								focusItem.focus();
 							}
 						}
-
-						instance._addedMessage = instance.byId('addedMessage');
-
-						instance._hideAddedMessageTask = A.debounce(A.bind('_hideAddedMessage', instance), 2000);
-
-						instance._eventHandles = [];
 
 						instance._bindUIDABase();
 					},

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
@@ -69,6 +69,8 @@ AUI.add(
 
 						instance._hideAddedMessageTask = A.debounce(A.bind('_hideAddedMessage', instance), 2000);
 
+						instance._panelBody = instance.get('panelBody');
+
 						if (instance._focusItem && instance._isSelected()) {
 							instance._focusItem.focus();
 						}
@@ -154,7 +156,7 @@ AUI.add(
 
 						instance._eventHandles.push(Liferay.after('showTab', instance._showTab, instance));
 
-						var panelBody = $('#' + instance.get('panelBody').get('id'));
+						var panelBody = $('#' + instance._panelBody.get('id'));
 
 						instance._eventHandles.push(panelBody.on('shown.bs.collapse', instance, instance._focusOnItem));
 					},
@@ -245,7 +247,7 @@ AUI.add(
 					_isSelected: function() {
 						var instance = this;
 
-						return instance.get('panelBody').hasClass('in');
+						return instance._panelBody.hasClass('in');
 					},
 
 					_portletFeedback: function(portletId, portlet) {

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
@@ -155,8 +155,17 @@ AUI.add(
 						var instance = this;
 
 						var panelBody = $('#' + instance._panelBody.get('id'));
+						var panelChildren = $('#' + instance._panelBody.get('id') + ' .list-group-panel');
 
-						instance._eventHandles.push(panelBody.on('shown.bs.collapse', instance, instance._focusOnItem));
+						instance._eventHandles.push(
+							panelBody.on('shown.bs.collapse', instance, instance._focusOnItem),
+							panelChildren.on(
+								'shown.bs.collapse',
+								function(event) {
+									event.stopPropagation();
+								}
+							)
+						);
 					},
 
 					_disablePortletEntry: function(portletId) {

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
@@ -155,6 +155,10 @@ AUI.add(
 						var instance = this;
 
 						instance._eventHandles.push(Liferay.after('showTab', instance._showTab, instance));
+
+						var panelBody = $('#' + instance.get('panelBody').get('id'));
+
+						instance._eventHandles.push(panelBody.on('shown.bs.collapse', instance, instance._focusOnItem));
 					},
 
 					_disablePortletEntry: function(portletId) {
@@ -185,6 +189,16 @@ AUI.add(
 								item.removeClass(CSS_LFR_PORTLET_USED);
 							}
 						);
+					},
+
+					_focusOnItem: function(event) {
+						var instance = event.data;
+
+						var focusItem = instance.get('focusItem');
+
+						if (focusItem) {
+							focusItem.focus();
+						}
 					},
 
 					_getPortletMetaData: function(portlet) {

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
@@ -65,7 +65,7 @@ AUI.add(
 					initializer: function(config) {
 						var instance = this;
 
-						if (instance.get('selected')) {
+						if (instance._isSelected()) {
 							var focusItem = instance.get('focusItem');
 
 							if (focusItem) {
@@ -234,6 +234,12 @@ AUI.add(
 						instance._addedMessage.hide(true);
 
 						instance._skipToContentHandle.detach();
+					},
+
+					_isSelected: function() {
+						var instance = this;
+
+						return instance.get('panelBody').hasClass('in');
 					},
 
 					_portletFeedback: function(portletId, portlet) {

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
@@ -48,6 +48,10 @@ AUI.add(
 						validator: Lang.isString
 					},
 
+					panelBody: {
+						setter: A.one
+					},
+
 					selected: {
 						validator: Lang.isBoolean
 					}

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
@@ -50,10 +50,6 @@ AUI.add(
 
 					panelBody: {
 						setter: A.one
-					},
-
-					selected: {
-						validator: Lang.isBoolean
 					}
 				},
 

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_base.js
@@ -65,14 +65,12 @@ AUI.add(
 
 						instance._eventHandles = [];
 
+						instance._focusItem = instance.get('focusItem');
+
 						instance._hideAddedMessageTask = A.debounce(A.bind('_hideAddedMessage', instance), 2000);
 
-						if (instance._isSelected()) {
-							var focusItem = instance.get('focusItem');
-
-							if (focusItem) {
-								focusItem.focus();
-							}
+						if (instance._focusItem && instance._isSelected()) {
+							instance._focusItem.focus();
 						}
 
 						instance._bindUIDABase();
@@ -194,10 +192,8 @@ AUI.add(
 					_focusOnItem: function(event) {
 						var instance = event.data;
 
-						var focusItem = instance.get('focusItem');
-
-						if (focusItem) {
-							focusItem.focus();
+						if (instance._focusItem) {
+							instance._focusItem.focus();
 						}
 					},
 
@@ -278,10 +274,8 @@ AUI.add(
 					_showTab: function(event) {
 						var instance = this;
 
-						var focusItem = instance.get('focusItem');
-
-						if (focusItem && event.tabSection && event.tabSection.contains(focusItem)) {
-							focusItem.focus();
+						if (instance._focusItem && event.tabSection && event.tabSection.contains(instance._focusItem)) {
+							instance._focusItem.focus();
 						}
 					},
 

--- a/modules/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/upgrade/v1_3_0/UpgradeClassNames.java
+++ b/modules/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/upgrade/v1_3_0/UpgradeClassNames.java
@@ -127,6 +127,24 @@ public class UpgradeClassNames extends UpgradeProcess {
 
 	static {
 		_classNamesMap.put(
+			"com.liferay.portal.model.Company",
+			"com.liferay.portal.kernel.model.Company");
+		_classNamesMap.put(
+			"com.liferay.portal.model.Group",
+			"com.liferay.portal.kernel.model.Group");
+		_classNamesMap.put(
+			"com.liferay.portal.model.LayoutRevision",
+			"com.liferay.portal.kernel.model.LayoutRevision");
+		_classNamesMap.put(
+			"com.liferay.portal.model.Role",
+			"com.liferay.portal.kernel.model.Role");
+		_classNamesMap.put(
+			"com.liferay.portal.model.User",
+			"com.liferay.portal.kernel.model.User");
+		_classNamesMap.put(
+			"com.liferay.portal.model.UserGroup",
+			"com.liferay.portal.kernel.model.UserGroup");
+		_classNamesMap.put(
 			"com.liferay.portlet.journal.model.JournalArticle",
 			"com.liferay.journal.model.JournalArticle");
 		_classNamesMap.put(


### PR DESCRIPTION
Hi Jon!

Update for: https://issues.liferay.com/browse/LPS-57867

Panels are now used instead of tabs, which has caused the focus functionality to no longer work. To focus on the search field when a panel is expanded, I had to wait until the panel was finished expanding. I had to use jQuery to listen for the bootstrap panel jQuery event. There was also a work around without jQuery involving `setTimeout` and listening to the panel header being clicked, but it resulted in a strange behavior where the panel contents would shift slightly down while expand. Let me know what your thoughts are on this approach.

I also added an `isSelected` function to continuously check if the panel was expanded since previously the `selected` property was only set once on initialization and was meaningless after the panels were interacted with.

Thanks!