### PR TITLE
LPS-63707 - We should not submit a form with an input called "p_p_lifecycle" and value "0" (Render Phase)

### DIFF
--- a/modules/apps/platform/roles/roles-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/platform/roles/roles-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -247,6 +247,8 @@ PortalUtil.addPortletBreadcrumbEntry(request, breadcrumbTitle, currentURL);
 
 		form.fm('deleteRoleIds').val(deleteRoleIds);
 
+		document.<portlet:namespace />fm.p_p_lifecycle.value = '1';
+
 		if (confirm('<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>')) {
 			submitForm(form, '<portlet:actionURL name="deleteRoles"><portlet:param name="redirect" value="<%= portletURL.toString() %>" /></portlet:actionURL>');
 		}


### PR DESCRIPTION
Hey Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-63707.

This bug ended up being almost exactly the same as https://issues.liferay.com/browse/LPS-63591.  This fix, which is the same as Bruno's, will make sure the `p_p_lifecycle` input will not have value of 0

Please let me know if there are any issues.

Thanks!