### PR TITLE
LPS-63179 - include newline char after minified javascript to prevent commenting out the first line of the next file if the current one ends in a comment

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
@@ -342,7 +342,7 @@ public class ComboServlet extends HttpServlet {
 				}
 				else if (minifierType.equals("js")) {
 					stringFileContent = MinifierUtil.minifyJavaScript(
-						resourcePath, stringFileContent);
+						resourcePath, stringFileContent) + StringPool.NEW_LINE;
 				}
 			}
 


### PR DESCRIPTION
Hey Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-63179.

This issue was happening when a JS file ended in a comment, like most of our Metal files do, and is minified and combo loaded.  The next file is stuck on the same line and is commented out, causing errors.

Please let me know if there are any issues.

Thanks!