### PR TITLE
LPS-63861 Tooltips message for asset publisher displays HTML code

### DIFF
--- a/modules/apps/web-experience-management/asset/asset-publisher-web/src/main/resources/META-INF/resources/asset_actions.jsp
+++ b/modules/apps/web-experience-management/asset/asset-publisher-web/src/main/resources/META-INF/resources/asset_actions.jsp
@@ -17,8 +17,6 @@
 <%@ include file="/init.jsp" %>
 
 <%
-boolean showIconLabel = ((Boolean)request.getAttribute("view.jsp-showIconLabel")).booleanValue();
-
 AssetRenderer<?> assetRenderer = (AssetRenderer<?>)request.getAttribute("view.jsp-assetRenderer");
 
 boolean showEditURL = ParamUtil.getBoolean(request, "showEditURL", true);
@@ -65,7 +63,7 @@ if (showEditURL && assetRenderer.hasEditPermission(permissionChecker)) {
 			icon="pencil"
 			label="<%= false %>"
 			markupView="lexicon"
-			message='<%= showIconLabel ? LanguageUtil.format(request, "edit-x-x", new Object[] {"hide-accessible", HtmlUtil.escape(assetRenderer.getTitle(locale))}, false) : LanguageUtil.format(request, "edit-x", HtmlUtil.escape(assetRenderer.getTitle(locale)), false) %>'
+			message='<%= LanguageUtil.format(request, "edit-x", HtmlUtil.escape(assetRenderer.getTitle(locale)), false) %>'
 			method="get"
 			url="<%= editPortletURL.toString() %>"
 			useDialog="<%= true %>"

--- a/modules/apps/web-experience-management/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/abstracts.jsp
+++ b/modules/apps/web-experience-management/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/abstracts.jsp
@@ -21,8 +21,6 @@ AssetEntry assetEntry = (AssetEntry)request.getAttribute("view.jsp-assetEntry");
 AssetRendererFactory<?> assetRendererFactory = (AssetRendererFactory<?>)request.getAttribute("view.jsp-assetRendererFactory");
 AssetRenderer<?> assetRenderer = (AssetRenderer<?>)request.getAttribute("view.jsp-assetRenderer");
 
-request.setAttribute("view.jsp-showIconLabel", true);
-
 String title = (String)request.getAttribute("view.jsp-title");
 
 if (Validator.isNull(title)) {

--- a/modules/apps/web-experience-management/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/full_content.jsp
+++ b/modules/apps/web-experience-management/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/full_content.jsp
@@ -50,7 +50,6 @@ assetPublisherDisplayContext.setLayoutAssetEntry(assetEntry);
 assetEntry = assetPublisherDisplayContext.incrementViewCounter(assetEntry);
 
 request.setAttribute("view.jsp-fullContentRedirect", currentURL);
-request.setAttribute("view.jsp-showIconLabel", true);
 %>
 
 <c:if test="<%= assetPublisherDisplayContext.isShowAssetTitle() %>">

--- a/modules/apps/web-experience-management/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/table.jsp
+++ b/modules/apps/web-experience-management/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/table.jsp
@@ -41,8 +41,6 @@ PortletURL editPortletURL = assetRenderer.getURLEdit(liferayPortletRequest, life
 boolean viewInContext = ((Boolean)request.getAttribute("view.jsp-viewInContext")).booleanValue();
 
 String viewURL = AssetPublisherHelper.getAssetViewURL(liferayPortletRequest, liferayPortletResponse, assetEntry, viewInContext);
-
-request.setAttribute("view.jsp-showIconLabel", false);
 %>
 
 <c:if test="<%= assetEntryIndex == 0 %>">

--- a/modules/apps/web-experience-management/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/title_list.jsp
+++ b/modules/apps/web-experience-management/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/title_list.jsp
@@ -31,8 +31,6 @@ if (Validator.isNull(title)) {
 	title = assetRenderer.getTitle(locale);
 }
 
-request.setAttribute("view.jsp-showIconLabel", false);
-
 boolean viewInContext = ((Boolean)request.getAttribute("view.jsp-viewInContext")).booleanValue();
 
 String viewURL = AssetPublisherHelper.getAssetViewURL(liferayPortletRequest, liferayPortletResponse, assetEntry, viewInContext);


### PR DESCRIPTION
remove ternary operator that has the same purpose as the label in asset_actions.jsp
remove boolean variable, setIconLabel, from multiple jsp files associated with asset publisher as they are not used