### PR TITLE
LPS-63581 Control Menu gets cut after prior navigation in Product Menu

### DIFF
--- a/modules/apps/web-experience/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_body.jsp
+++ b/modules/apps/web-experience/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_body.jsp
@@ -22,7 +22,7 @@
 	String portletNamespace = PortalUtil.getPortletNamespace(ProductNavigationControlMenuPortletKeys.PRODUCT_NAVIGATION_CONTROL_MENU);
 	%>
 
-	<div class="closed lfr-add-panel lfr-admin-panel lfr-product-menu-panel sidenav-fixed sidenav-menu-slider sidenav-right" id="<%= portletNamespace %>addPanelId">
+	<div class="closed lfr-add-panel lfr-admin-panel sidenav-fixed sidenav-menu-slider sidenav-right" id="<%= portletNamespace %>addPanelId">
 		<div class="product-menu sidebar sidebar-body sidebar-inverse">
 			<h4 class="sidebar-header">
 				<span><liferay-ui:message key="add" /></span>


### PR DESCRIPTION
Hi @jonmak08,

Update for https://issues.liferay.com/browse/LPS-63581.

The issue is caused by the styles from `product-navigation-product-menu-web` overriding the styles from `product-navigation-control-menu-theme-contributor`. I didn't figure out exactly why it was only overriding in some cases, but I thought it might be from the loading order of specifically the stylesheets. Either way the panel menu styles shouldn't be overriding the control-menu styles so I went for a CSS fix.

I removed `lfr-product-menu-panel` since `lfr-admin-panel` styles were completely overriding it anyway, which seems to be intended since `lfr-admin-panel` styles are part of the `control-menu-web`.

Let me know if you have any questions. Thanks!