### PR TITLE
LPS-63118 - Last row of entries in card display style when a displaying the maximum entries per page is uneven

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -5537,6 +5537,17 @@ auto.deploy.dest.dir=C:/WINDOWS/system32/config/systemprofile/liferay/websphere-
 		</if>
 
 		<if>
+			<equals arg1="${browser.type}" arg2="edge" />
+			<then>
+				<prepare-edge-driver />
+
+				<echo append="true" file="${test.ext.properties.file}">
+					selenium.executable.dir.name=${selenium.executable.dir.name}
+				</echo>
+			</then>
+		</if>
+
+		<if>
 			<equals arg1="${browser.type}" arg2="internetexplorer" />
 			<then>
 				<prepare-ie-driver />

--- a/build-test.xml
+++ b/build-test.xml
@@ -1341,6 +1341,28 @@ counter.jdbc.prefix=jdbc.counter.]]></echo>
 		</sequential>
 	</macrodef>
 
+	<macrodef name="prepare-edge-driver">
+		<sequential>
+			<if>
+				<os family="windows" />
+				<then>
+					<mirrors-get
+						dest="tools/selenium/MicrosoftWebDriver.exe"
+						src="http://www.microsoft.com/en-us/download/webdriver/2.0/MicrosoftWebDriver.exe"
+					/>
+				</then>
+				<else>
+					<if>
+						<equals arg1="${selenium.remote.driver.enabled}" arg2="false" />
+						<then>
+							<fail message="Operating system is not supported." />
+						</then>
+					</if>
+				</else>
+			</if>
+		</sequential>
+	</macrodef>
+
 	<macrodef name="prepare-elasticsearch-configuration" >
 		<sequential>
 			<echo file="${liferay.home}/osgi/portal/com.liferay.portal.search.elasticsearch.configuration.ElasticsearchConfiguration.cfg">

--- a/modules/apps/collaboration/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/entry_search_columns.jspf
+++ b/modules/apps/collaboration/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/entry_search_columns.jspf
@@ -52,7 +52,7 @@
 	<c:when test='<%= displayStyle.equals("icon") %>'>
 
 		<%
-		row.setCssClass("entry-card col-md-3 col-sm-4");
+		row.setCssClass("article-entry entry-card");
 		%>
 
 		<liferay-ui:search-container-column-text>

--- a/modules/apps/collaboration/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/image_search_columns.jspf
+++ b/modules/apps/collaboration/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/image_search_columns.jspf
@@ -57,7 +57,7 @@ String thumbnailSrc = DLUtil.getThumbnailSrc(fileEntry, themeDisplay);
 	<c:when test='<%= displayStyle.equals("icon") %>'>
 
 		<%
-		row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6");
+		row.setCssClass("article-entry");
 		%>
 
 		<liferay-ui:search-container-column-text>

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/upload.js
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/upload.js
@@ -136,7 +136,7 @@ AUI.add(
 				'</a>' +
 			'</span>';
 
-		var TPL_ENTRY_WRAPPER = '<li class="col-md-2 col-sm-4 col-xs-6" data-title="{title}"></li>';
+		var TPL_ENTRY_WRAPPER = '<li class="article-entry" data-title="{title}"></li>';
 
 		var TPL_ERROR_FOLDER = new A.Template(
 			'<span class="lfr-status-success-label">{validFilesLength}</span>',

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -321,7 +321,7 @@ if (portletTitleBasedNavigation && (folderId != DLFolderConstants.DEFAULT_PARENT
 						<c:when test='<%= displayStyle.equals("icon") %>'>
 
 							<%
-							row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6");
+							row.setCssClass("article-entry");
 							%>
 
 							<liferay-ui:search-container-column-text>
@@ -496,7 +496,7 @@ if (portletTitleBasedNavigation && (folderId != DLFolderConstants.DEFAULT_PARENT
 						<c:when test='<%= displayStyle.equals("icon") %>'>
 
 							<%
-							row.setCssClass("col-md-3 col-sm-4 folder-entry");
+							row.setCssClass("folder-entry");
 
 							PortletURL rowURL = liferayPortletResponse.createRenderURL();
 

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
@@ -83,8 +83,6 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 						}
 					}
 				}
-
-				row.setClassName("col-md-4 col-sm-4 col-xs-6");
 				%>
 
 				<liferay-ui:search-container-column-text>
@@ -120,10 +118,6 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 					<portlet:param name="redirect" value="<%= currentURL %>" />
 					<portlet:param name="folderId" value="<%= String.valueOf(curFolder.getFolderId()) %>" />
 				</portlet:renderURL>
-
-				<%
-				row.setCssClass("col-md-4 col-sm-4 col-xs-6");
-				%>
 
 				<liferay-ui:search-container-column-text>
 					<liferay-frontend:horizontal-card

--- a/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -330,8 +330,6 @@ if (Validator.isNotNull(keywords)) {
 								}
 
 								if (fileEntry != null) {
-									row.setCssClass("col-lg-3 col-md-3 col-sm-4 col-xs-6");
-
 									FileVersion latestFileVersion = fileEntry.getLatestFileVersion();
 
 									String title = DLUtil.getTitleWithExtension(fileEntry);

--- a/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_search_iterator.scss
+++ b/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_search_iterator.scss
@@ -114,6 +114,31 @@
 	}
 }
 
+.display-style-icon {
+	.article-entry, .folder-entry {
+		float: left;
+		padding-left: 15px;
+		padding-right: 15px;
+		width: 100%;
+
+		@include respond-to(tablet) {
+			width: 33.33333%;
+		}
+	}
+
+	.article-entry {
+		@include respond-to(desktop) {
+			width: 20%;
+		}
+	}
+
+	.folder-entry {
+		@include respond-to(desktop) {
+			width: 25%;
+		}
+	}
+}
+
 .article-entry {
 	min-width: 150px;
 }

--- a/modules/apps/foundation/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/organization_search_columns.jspf
+++ b/modules/apps/foundation/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/organization_search_columns.jspf
@@ -56,7 +56,7 @@
 		<c:when test='<%= displayStyle.equals("icon") %>'>
 
 			<%
-			row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6");
+			row.setCssClass("article-entry");
 			%>
 
 			<liferay-ui:search-container-column-text>

--- a/modules/apps/foundation/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/user_search_columns.jspf
+++ b/modules/apps/foundation/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/user_search_columns.jspf
@@ -55,7 +55,7 @@
 		<c:when test='<%= displayStyle.equals("icon") %>'>
 
 			<%
-			row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6");
+			row.setCssClass("article-entry");
 			%>
 
 			<liferay-ui:search-container-column-text>

--- a/modules/apps/foundation/roles/roles-admin-web/src/main/resources/META-INF/resources/organization_columns.jspf
+++ b/modules/apps/foundation/roles/roles-admin-web/src/main/resources/META-INF/resources/organization_columns.jspf
@@ -44,7 +44,7 @@
 	<c:when test='<%= displayStyle.equals("icon") %>'>
 
 		<%
-		row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6 selectable");
+		row.setCssClass("article-entry selectable");
 		%>
 
 		<liferay-ui:search-container-column-text>

--- a/modules/apps/foundation/roles/roles-admin-web/src/main/resources/META-INF/resources/site_columns.jspf
+++ b/modules/apps/foundation/roles/roles-admin-web/src/main/resources/META-INF/resources/site_columns.jspf
@@ -34,7 +34,7 @@
 	<c:when test='<%= displayStyle.equals("icon") %>'>
 
 		<%
-		row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6 selectable");
+		row.setCssClass("article-entry selectable");
 		%>
 
 		<liferay-ui:search-container-column-text>

--- a/modules/apps/foundation/roles/roles-admin-web/src/main/resources/META-INF/resources/user_columns.jspf
+++ b/modules/apps/foundation/roles/roles-admin-web/src/main/resources/META-INF/resources/user_columns.jspf
@@ -36,7 +36,7 @@
 	<c:when test='<%= displayStyle.equals("icon") %>'>
 
 		<%
-		row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6 selectable");
+		row.setCssClass("article-entry selectable");
 		%>
 
 		<liferay-ui:search-container-column-text>

--- a/modules/apps/foundation/roles/roles-admin-web/src/main/resources/META-INF/resources/user_group_columns.jspf
+++ b/modules/apps/foundation/roles/roles-admin-web/src/main/resources/META-INF/resources/user_group_columns.jspf
@@ -34,7 +34,7 @@
 	<c:when test='<%= displayStyle.equals("icon") %>'>
 
 		<%
-		row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6 selectable");
+		row.setCssClass("article-entry selectable");
 		%>
 
 		<liferay-ui:search-container-column-text>

--- a/modules/apps/foundation/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/user_search_columns.jspf
+++ b/modules/apps/foundation/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/user_search_columns.jspf
@@ -42,7 +42,7 @@
 	<c:when test='<%= displayStyle.equals("icon") %>'>
 
 		<%
-		row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6");
+		row.setCssClass("article-entry");
 		%>
 
 		<liferay-ui:search-container-column-text>

--- a/modules/apps/web-experience/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-experience/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -124,8 +124,6 @@
 				<c:when test='<%= assetBrowserDisplayContext.getDisplayStyle().equals("icon") %>'>
 
 					<%
-					row.setCssClass("col-md-2 col-sm-4 col-xs-6");
-
 					AssetRenderer assetRenderer = assetEntry.getAssetRenderer();
 					%>
 

--- a/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_comments.jsp
+++ b/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_comments.jsp
@@ -63,7 +63,7 @@ String displayStyle = journalDisplayContext.getDisplayStyle();
 			<c:when test='<%= displayStyle.equals("icon") %>'>
 
 				<%
-				row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6");
+				row.setCssClass("article-entry");
 				%>
 
 				<liferay-ui:search-container-column-text>

--- a/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -131,7 +131,7 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 					<c:when test='<%= displayStyle.equals("icon") %>'>
 
 						<%
-						row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6 " + row.getCssClass());
+						row.setCssClass("article-entry " + row.getCssClass());
 						%>
 
 						<liferay-ui:search-container-column-text>
@@ -296,7 +296,7 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 					<c:when test='<%= displayStyle.equals("icon") %>'>
 
 						<%
-						row.setCssClass("col-md-3 col-sm-4 folder-entry " + row.getCssClass());
+						row.setCssClass("folder-entry " + row.getCssClass());
 						%>
 
 						<liferay-ui:search-container-column-text colspan="<%= 2 %>">

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/select_theme.jsp
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/select_theme.jsp
@@ -97,8 +97,6 @@ themes = ListUtil.sort(themes, new ThemeNameComparator(orderByType.equals("asc")
 		>
 
 			<%
-			row.setCssClass("col-md-2 col-sm-3 col-xs-6");
-
 			PluginPackage selPluginPackage = theme.getPluginPackage();
 
 			String cssClass = "theme-selector";

--- a/modules/apps/web-experience/layout/layout-prototype-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-experience/layout/layout-prototype-web/src/main/resources/META-INF/resources/view.jsp
@@ -166,11 +166,6 @@ PortletURL portletURL = renderResponse.createRenderURL();
 					/>
 				</c:when>
 				<c:when test='<%= displayStyle.equals("icon") %>'>
-
-					<%
-					row.setCssClass("col-md-2 col-sm-4 col-xs-6");
-					%>
-
 					<liferay-ui:search-container-column-text>
 						<liferay-frontend:icon-vertical-card
 							actionJsp="/layout_prototype_action.jsp"

--- a/modules/apps/web-experience/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-experience/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/view.jsp
@@ -173,11 +173,6 @@ PortletURL portletURL = renderResponse.createRenderURL();
 					/>
 				</c:when>
 				<c:when test='<%= displayStyle.equals("icon") %>'>
-
-					<%
-					row.setCssClass("col-md-2 col-sm-4 col-xs-6");
-					%>
-
 					<liferay-ui:search-container-column-text>
 						<liferay-frontend:icon-vertical-card
 							actionJsp="/layout_set_prototype_action.jsp"

--- a/modules/apps/web-experience/site/site-admin-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -47,7 +47,7 @@ SearchContainer groupSearch = (SearchContainer)request.getAttribute("view.jsp-gr
 			<c:when test='<%= displayStyle.equals("icon") %>'>
 
 				<%
-				row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6 " + row.getCssClass());
+				row.setCssClass("article-entry " + row.getCssClass());
 				%>
 
 				<liferay-portlet:renderURL var="viewSubsitesURL">

--- a/modules/apps/web-experience/site/site-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-experience/site/site-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -114,7 +114,7 @@ PortletURL portletURL = siteBrowserDisplayContext.getPortletURL();
 				<c:when test='<%= displayStyle.equals("icon") %>'>
 
 					<%
-					row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6 " + row.getCssClass());
+					row.setCssClass("article-entry " + row.getCssClass());
 					%>
 
 					<liferay-ui:search-container-column-text>

--- a/modules/apps/web-experience/site/site-item-selector-web/src/main/resources/META-INF/resources/view_sites.jsp
+++ b/modules/apps/web-experience/site/site-item-selector-web/src/main/resources/META-INF/resources/view_sites.jsp
@@ -89,7 +89,7 @@ PortletURL portletURL = siteItemSelectorViewDisplayContext.getPortletURL();
 				<c:when test='<%= displayStyle.equals("icon") %>'>
 
 					<%
-					row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6 " + row.getCssClass());
+					row.setCssClass("article-entry " + row.getCssClass());
 
 					Map<String, Object> linkData = new HashMap<String, Object>();
 

--- a/modules/apps/web-experience/site/site-memberships-web/src/main/resources/META-INF/resources/organization_columns.jspf
+++ b/modules/apps/web-experience/site/site-memberships-web/src/main/resources/META-INF/resources/organization_columns.jspf
@@ -30,7 +30,7 @@ Group group = siteMembershipsDisplayContext.getGroup();
 	<c:when test='<%= displayStyle.equals("icon") %>'>
 
 		<%
-		row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6");
+		row.setCssClass("article-entry");
 		%>
 
 		<liferay-ui:search-container-column-text>

--- a/modules/apps/web-experience/site/site-memberships-web/src/main/resources/META-INF/resources/user_columns.jspf
+++ b/modules/apps/web-experience/site/site-memberships-web/src/main/resources/META-INF/resources/user_columns.jspf
@@ -67,7 +67,7 @@ names.addAll(ListUtil.toList(teams, Team.NAME_ACCESSOR));
 	<c:when test='<%= displayStyle.equals("icon") %>'>
 
 		<%
-		row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6");
+		row.setCssClass("article-entry");
 		%>
 
 		<liferay-ui:search-container-column-text>

--- a/modules/apps/web-experience/site/site-memberships-web/src/main/resources/META-INF/resources/user_group_columns.jspf
+++ b/modules/apps/web-experience/site/site-memberships-web/src/main/resources/META-INF/resources/user_group_columns.jspf
@@ -30,7 +30,7 @@ String userGroupGroupRolesString = ListUtil.toString(userGroupGroupRoles, UsersA
 	<c:when test='<%= displayStyle.equals("icon") %>'>
 
 		<%
-		row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6");
+		row.setCssClass("article-entry");
 		%>
 
 		<liferay-ui:search-container-column-text>

--- a/modules/apps/web-experience/site/site-teams-web/src/main/resources/META-INF/resources/user_columns.jspf
+++ b/modules/apps/web-experience/site/site-teams-web/src/main/resources/META-INF/resources/user_columns.jspf
@@ -18,7 +18,7 @@
 	<c:when test='<%= displayStyle.equals("icon") %>'>
 
 		<%
-		row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6 selectable");
+		row.setCssClass("article-entry selectable");
 		%>
 
 		<liferay-ui:search-container-column-text>

--- a/modules/apps/web-experience/site/site-teams-web/src/main/resources/META-INF/resources/user_group_columns.jspf
+++ b/modules/apps/web-experience/site/site-teams-web/src/main/resources/META-INF/resources/user_group_columns.jspf
@@ -26,7 +26,7 @@ int usersCount = UserLocalServiceUtil.searchCount(company.getCompanyId(), String
 	<c:when test='<%= displayStyle.equals("icon") %>'>
 
 		<%
-		row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6 selectable");
+		row.setCssClass("article-entry selectable");
 		%>
 
 		<liferay-ui:search-container-column-text>

--- a/modules/apps/web-experience/site/site-teams-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-experience/site/site-teams-web/src/main/resources/META-INF/resources/view.jsp
@@ -159,7 +159,7 @@ teamSearchContainer.setTotal(teamsCount);
 				<c:when test='<%= displayStyle.equals("icon") %>'>
 
 					<%
-					row.setCssClass("article-entry col-md-2 col-sm-4 col-xs-6");
+					row.setCssClass("article-entry");
 					%>
 
 					<liferay-ui:search-container-column-text>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMRepository.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMRepository.macro
@@ -33,6 +33,10 @@
 		<execute function="MakeVisible" locator1="DocumentsAndMedia#ICON_FOLDER_THUMBNAIL_GENERIC" />
 
 		<execute function="AssertClick" locator1="DocumentsAndMedia#FILTER_REPOSITORY" value1="${dmRepositoryName}" />
+
+		<var name="key_dmFolderName" value="${dmRepositoryName}" />
+
+		<execute function="AssertVisible" locator1="DocumentsAndMedia#BREADCRUMB_FOLDER_NAME" />
 	</command>
 
 	<command name="tearDownCP">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ServerAdministration.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ServerAdministration.macro
@@ -77,12 +77,32 @@
 		<execute function="Type" locator1="ServerAdministrationMail#INCOMING_POP_SERVER" value1="pop.gmail.com" />
 		<execute function="Type" locator1="ServerAdministrationMail#INCOMING_PORT" value1="995" />
 		<execute function="Check" locator1="ServerAdministrationMail#INCOMING_SECURE_NETWORK_CONNECTION_CHECKBOX" />
-		<execute function="Type" locator1="ServerAdministrationMail#INCOMING_USER_NAME" value1="${userName}" />
+
+		<if>
+			<equals arg1="needsReply" arg2="true" />
+			<then>
+				<execute function="Type" locator1="ServerAdministrationMail#INCOMING_USER_NAME" value1="recent:${userName}" />
+			</then>
+			<else>
+				<execute function="Type" locator1="ServerAdministrationMail#INCOMING_USER_NAME" value1="${userName}" />
+			</else>
+		</if>
+
 		<execute function="Type" locator1="ServerAdministrationMail#INCOMING_PASSWORD" value1="${userPassword}" />
 		<execute function="Type" locator1="ServerAdministrationMail#OUTGOING_SMTP_SERVER" value1="smtp.gmail.com" />
 		<execute function="Type" locator1="ServerAdministrationMail#OUTGOING_PORT" value1="465" />
 		<execute function="Check" locator1="ServerAdministrationMail#OUTGOING_SECURE_CONNECTION_CHECKBOX" />
-		<execute function="Type" locator1="ServerAdministrationMail#OUTGOING_USER_NAME" value1="${userName}" />
+
+		<if>
+			<equals arg1="needsReply" arg2="true" />
+			<then>
+				<execute function="Type" locator1="ServerAdministrationMail#OUTGOING_USER_NAME" value1="recent:${userName}" />
+			</then>
+			<else>
+				<execute function="Type" locator1="ServerAdministrationMail#OUTGOING_USER_NAME" value1="${userName}" />
+			</else>
+		</if>
+
 		<execute function="Type" locator1="ServerAdministrationMail#OUTGOING_PASSWORD" value1="${userPassword}" />
 		<execute function="AssertClick" locator1="CPServeradministrationMail#SAVE_BUTTON" value1="Save" />
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/BlogsAggregator.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/BlogsAggregator.path
@@ -21,7 +21,7 @@
 <!--ENTRY-->
 <tr>
 	<td>ENTRY_TITLE</td>
-	<td>//span[@class='entry-title']//a[contains(.,'${key_entryTitle}')]</td>
+	<td>//h2[contains(.,'Blogs Aggregator')]/..//div[contains(@class,'entry-title') and contains(.,'${key_entryTitle}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/StagingPublishToLive.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/StagingPublishToLive.path
@@ -182,12 +182,12 @@
 <!--DATE_RANGE-->
 <tr>
 	<td>DATE_RANGE_START_DATE</td>
-	<td>xpath=(//input[contains(@name,'startDate') and contains(@type,'text')])[1]</td>
+	<td>xpath=(//ul[contains(@class,'date-range-options')]//input[contains(@name,'startDate') and contains(@type,'text')])[1]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>DATE_RANGE_END_DATE</td>
-	<td>xpath=(//input[contains(@name,'endDate') and contains(@type,'text')])[1]</td>
+	<td>xpath=(//ul[contains(@class,'date-range-options')]//input[contains(@name,'endDate') and contains(@type,'text')])[1]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/pgmessageboards/PGMessageboards.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/pgmessageboards/PGMessageboards.testcase
@@ -1181,24 +1181,13 @@
 			<var name="categoryName" value="MB Category Name" />
 		</execute>
 
-		<var name="key_threadSubject" value="MB Thread Message Subject" />
-
-		<execute function="AssertTextEquals" locator1="MessageBoards#THREAD_LIST_THREAD" value1="MB Thread Message Subject" />
-		<execute function="AssertTextEquals" locator1="MessageBoards#THREAD_LIST_LAST_POST" value1="Test Test" />
-		<execute function="AssertTextEquals" locator1="MessageBoards#THREAD_TABLE_POSTS" value1="2 Posts" />
-		<execute function="AssertTextEquals#assertPartialText" locator1="MessageBoards#THREAD_TABLE_LAST_POST" value1="userfn userln" />
-		<execute function="Click" locator1="MessageBoards#THREAD_LIST_THREAD" value1="MB Thread Message Subject" />
-
-		<execute function="AssertTextEquals" locator1="MessageBoardsThread#THREAD_TABLE_SUBJECT_1" value1="MB Thread Message Subject" />
-		<execute function="AssertTextEquals" locator1="MessageBoardsThread#THREAD_TABLE_SUBJECT_2" value1="RE: MB Thread Message Subject" />
-		<execute function="AssertTextEquals" locator1="MessageBoardsThread#MESSAGE_SUBJECT_1" value1="MB Thread Message Subject" />
-		<execute function="AssertTextEquals" locator1="MessageBoardsThread#MESSAGE_BODY_1" value1="MB Thread Message Body" />
-		<execute function="AssertTextEquals" locator1="MessageBoardsThread#MESSAGE_USERNAME_1" value1="Test Test" />
-		<execute function="AssertTextEquals" locator1="MessageBoardsThread#MESSAGE_RATING_1" value1="0 (0 Votes)" />
-		<execute function="AssertTextEquals" locator1="MessageBoardsThread#MESSAGE_SUBJECT_2" value1="RE: MB Thread Message Subject" />
-		<execute function="AssertTextEquals#assertPartialText" locator1="MessageBoardsThread#MESSAGE_BODY_2" value1="MB Thread Message Subject Reply" />
-		<execute function="AssertTextEquals" locator1="MessageBoardsThread#MESSAGE_USERNAME_2" value1="userfn userln" />
-		<execute function="AssertTextEquals" locator1="MessageBoardsThread#MESSAGE_RATING_2" value1="0 (0 Votes)" />
+		<execute macro="MessageboardsThread#viewReplyPG">
+			<var name="postCount" value="2" />
+			<var name="threadBody" value="MB Thread Message Body" />
+			<var name="threadReplyBody" value="MB Thread Message Subject Reply" />
+			<var name="threadSubject" value="MB Thread Message Subject" />
+			<var name="userName" value="userfn userln" />
+		</execute>
 
 		<execute macro="Gmail#tearDown">
 			<var method="TestPropsUtil#get('email.address.2')" name="userEmailAddress" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/pgmessageboards/PGMessageboards.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/pgmessageboards/PGMessageboards.testcase
@@ -1054,6 +1054,7 @@
 		</execute>
 
 		<execute macro="ServerAdministration#configureMailServerSettings">
+			<var name="needsReply" value="true" />
 			<var method="TestPropsUtil#get('email.address.1')" name="userName" />
 			<var method="TestPropsUtil#get('email.password.1')" name="userPassword" />
 		</execute>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/pgmessageboards/PGMessageboards.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/pgmessageboards/PGMessageboards.testcase
@@ -1047,7 +1047,7 @@
 	</command>
 
 	<command name="ViewMBThreadAndReplyThreadInGmail" priority="4">
-		<property name="custom.properties" value="pop.server.notifications.enabled=true{line.separator}pop.server.subdomain=" />
+		<property name="custom.properties" value="message.boards.message.formats.default=html{line.separator}pop.server.notifications.enabled=true{line.separator}pop.server.subdomain={line.separator}mail.session.mail.smtp.socketFactory.class=javax.net.ssl.SSLSocketFactory{line.separator}mail.session.mail.pop3.socketFactory.class=javax.net.ssl.SSLSocketFactory" />
 
 		<execute macro="ProductMenu#gotoControlPanelConfiguration">
 			<var name="portlet" value="Server Administration" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/pgmessageboards/PGMessageboards.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/pgmessageboards/PGMessageboards.testcase
@@ -1173,6 +1173,10 @@
 
 		<execute function="Pause" locator1="60000" />
 
+		<execute function="Refresh" />
+
+		<execute function="AssertVisible" locator1="Notifications#PROFILE_BADGE_COUNT" />
+
 		<execute macro="Navigator#gotoPage">
 			<var name="pageName" value="${pageName}" />
 		</execute>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/sitesadministration/cpsitememberships/CPSitememberships.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/sitesadministration/cpsitememberships/CPSitememberships.testcase
@@ -489,7 +489,7 @@
 	</command>
 
 	<command name="OrganizationsView" priority="5">
-		<property name="portal.acceptance" value="false" />
+		<property name="portal.acceptance" value="true" />
 
 		<execute macro="ProductMenu#gotoControlPanelUsers">
 			<var name="portlet" value="Users and Organizations" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/staging/usecase/StagingUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/staging/usecase/StagingUsecase.testcase
@@ -653,7 +653,6 @@
 
 		<execute macro="Page#add">
 			<var name="pageName" value="Blogs Page 1" />
-			<var name="siteName" value="Site Name" />
 		</execute>
 
 		<execute macro="Portlet#addPG">
@@ -680,7 +679,6 @@
 
 		<execute macro="Page#add">
 			<var name="pageName" value="Blogs Page 2" />
-			<var name="siteName" value="Site Name" />
 		</execute>
 
 		<execute macro="Portlet#addPG">
@@ -1045,6 +1043,8 @@
 		<execute macro="ProductMenu#gotoControlPanelUsers">
 			<var name="portlet" value="Users and Organizations" />
 		</execute>
+
+		<execute function="Pause" locator1="1000" />
 
 		<execute macro="User#addCP">
 			<var name="userEmailAddress" value="userea@liferay.com" />


### PR DESCRIPTION
Hey Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-63118.

I talked to @pat270 about these changes (https://github.com/pat270/liferay-portal/pull/159#issuecomment-193405225) and we think we should do away with the bootstrap grid for the icon view and try and use our own custom column sizes and breakpoints.

This is a big change but I think it's the only way to accomplish the 'even-ness' requested in the ticket.  As Patrick pointed out there is still going to be an issue in some portlets where folders are treated differently but still count towards the maximum entries per page.  But I think that is unavoidable.  

Please let me know if there are any issues.

Thanks!