### PR TITLE
LPS-63904 - TypeError when moving document to recycle bin

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/ratings.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/ratings.js
@@ -223,11 +223,14 @@ AUI.add(
 						ratings = Liferay.Ratings.ThumbRating;
 					}
 
-					var ratingInstance = new ratings(config);
+					if (config.type != 'stars' || document.getElementById(config.containerId) != null) {
+						var ratingInstance = new ratings(config);
 
-					instance._INSTANCES[config.id || config.namespace] = ratingInstance;
+						instance._INSTANCES[config.id || config.namespace] = ratingInstance;
 
-					return ratingInstance;
+						return ratingInstance;
+					}
+
 				},
 
 				_registerTask: A.debounce(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/cpdocumentsandmedia/CPDocumentsandmedia.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/cpdocumentsandmedia/CPDocumentsandmedia.testcase
@@ -254,6 +254,8 @@
 	</command>
 
 	<command name="MoveToRecycleBinDocument" priority="5">
+		<property name="portal.acceptance" value="testing" />
+
 		<var name="assetName" value="${dmDocumentTitle}" />
 		<var name="assetType" value="Document" />
 		<var name="dmDocumentDescription" value="DM Document Description1" />


### PR DESCRIPTION
Hey Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-63904.

I was never able to actually reproduce this locally, either manually or with running the selenium test locally.  But by sending myself a pull and enabling the test to run, I was kinda able to debug it.  The fix is pretty simple, don't create the stars ratings instance if the element is not on the page.  I'm still not 100% sure why this would happen, and only happen once with a fresh portal instance.  But this should prevent it.

Please let me know if there are any issues.

Thanks!