### PR TITLE
LPS-64284 - Add scrolling to portlets when alerts overflow

### DIFF
--- a/modules/apps/foundation/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
@@ -45,6 +45,11 @@ body.portlet {
 	padding: 12px 10px 10px;
 }
 
+.portlet-content {
+	overflow: auto;
+	position: relative;
+}
+
 .portlet-minimized .portlet-content {
 	padding: 0;
 }


### PR DESCRIPTION
Update for: https://issues.liferay.com/browse/LPS-64284

I thought the correct fix for this would have only the alerts scrollable, but since it was absolutely positioned that would mean setting the height 100% of the `portlet-body` and since alerts aren't always at the top of the `portlet-body`, I didn't see a clean fix with this. Plus when viewing the full page of the portlet (from the product menu) `portlet-body` doesn't expand the full height of the page making the alerts get cut off in the middle of the page.

I instead had the portlet scrollable when there's an overflow unless it'd be best to have the overflowing alerts hidden.

Let me know what you think. Thanks!
