### PR TITLE
LPS-64168 Control Menu help tip for Info icon is overlapped

### DIFF
--- a/portal-web/docroot/html/taglib/ui/icon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/page.jsp
@@ -131,9 +131,10 @@ boolean urlIsNotNull = Validator.isNotNull(url);
 		<aui:script use="aui-tooltip">
 			var tooltip = new A.TooltipDelegate(
 				{
-					position: 'right',
+					position: 'bottom',
 					trigger: '.lfr-portal-tooltip',
-					visible: false
+					visible: false,
+					zIndex: 10001
 				}
 			);
 


### PR DESCRIPTION
adjust tooltip to display above and at the bottom of the icon info message