### PR TITLE
LPS-64756 Mobile - Control Menu expands into Product Menu

### DIFF
--- a/modules/apps/web-experience/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_variables.scss
+++ b/modules/apps/web-experience/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_variables.scss
@@ -1,4 +1,4 @@
-$admin-panel-width: 350px;
+$admin-panel-width: 320px;
 
 $control-menu-css-transition: all 0.5s ease !default;
 


### PR DESCRIPTION
Adjust control menu width to the same size as the product menu to prevent overlap with icon