### PR TITLE
Lps 64868 - Focus on Sign-In Modal's Input Upon First Clicking "Sign In"

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/sign_in_modal.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/sign_in_modal.js
@@ -14,7 +14,7 @@ AUI.add(
 
 					signInPortlet: {
 						setter: A.one,
-						value: '#p_p_id_58_'
+						value: '#p_p_id_com_liferay_login_web_portlet_LoginPortlet_'
 					}
 				},
 

--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/sign_in_modal.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/sign_in_modal.js
@@ -184,6 +184,10 @@ AUI.add(
 
 							dialog.show();
 						}
+
+						setTimeout(function() {
+							Liferay.Util.focusFormField(A.one('#_com_liferay_login_web_portlet_LoginPortlet_login'));
+						}, 0);
 					}
 				}
 			}


### PR DESCRIPTION
Hey @jonmak08 ,

Please check the PR for this ticket!

Notes:
- setTimeout has to be allow for the creation of the element before targeting it
- the sign_in_modal.js file may have to be re-written over again since the portlet changed


Thanks Jon!
Tyler