### PR TITLE
LPS-65343 - remove random senna 'zx' param from query string in filters, so that css resources can be cached on the server

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/css/main.scss
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/css/main.scss
@@ -5,6 +5,10 @@
 		clear: both;
 	}
 
+	.lfr-search-container-wrapper {
+		padding: 0 15px;
+	}
+
 	.carousel.image-viewer-base {
 		margin: 0 auto;
 		max-height: 100%;

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
@@ -150,7 +150,7 @@ public class DDLRecordSearchTest {
 
 				@Override
 				public Void call() throws Exception {
-					searchContext.setKeywords("description");
+					searchContext.setKeywords("Simple description");
 
 					Hits hits = DDLRecordLocalServiceUtil.search(searchContext);
 

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib-web/src/main/resources/META-INF/resources/card/vertical_card/end.jspf
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib-web/src/main/resources/META-INF/resources/card/vertical_card/end.jspf
@@ -50,16 +50,14 @@
 		</div>
 
 		<c:if test="<%= showCheckbox %>">
-			<label>
-				<c:choose>
-					<c:when test="<%= (rowChecker != null) && (resultRow != null) %>">
-						<%= rowChecker.getRowCheckBox(request, rowChecker.isChecked(resultRow.getObject()), rowChecker.isDisabled(resultRow.getObject()), resultRow.getPrimaryKey()) %>
-					</c:when>
-					<c:when test="<%= showCheckbox %>">
-						<aui:input checked="<%= checkboxChecked %>" cssClass="<%= checkboxCSSClass %>" data="<%= checkboxData %>" disabled="<%= checkboxDisabled %>" id="<%= checkboxId %>" label="" name="<%= checkboxName %>" title='<%= LanguageUtil.format(request, "select-x", new Object[] {HtmlUtil.escape(title)}) %>' type="checkbox" useNamespace="<%= false %>" value="<%= checkboxValue %>" wrappedField="<%= true %>" />
-					</c:when>
-				</c:choose>
-			</label>
+			<c:choose>
+				<c:when test="<%= (rowChecker != null) && (resultRow != null) %>">
+					<%= rowChecker.getRowCheckBox(request, rowChecker.isChecked(resultRow.getObject()), rowChecker.isDisabled(resultRow.getObject()), resultRow.getPrimaryKey()) %>
+				</c:when>
+				<c:when test="<%= showCheckbox %>">
+					<aui:input checked="<%= checkboxChecked %>" cssClass="<%= checkboxCSSClass %>" data="<%= checkboxData %>" disabled="<%= checkboxDisabled %>" id="<%= checkboxId %>" label="" name="<%= checkboxName %>" title='<%= LanguageUtil.format(request, "select-x", new Object[] {HtmlUtil.escape(title)}) %>' type="checkbox" useNamespace="<%= false %>" value="<%= checkboxValue %>" wrappedField="<%= true %>" />
+				</c:when>
+			</c:choose>
 		</c:if>
 	</div>
 </div>

--- a/modules/apps/foundation/petra/petra-encryptor/bnd.bnd
+++ b/modules/apps/foundation/petra/petra-encryptor/bnd.bnd
@@ -3,7 +3,7 @@ Bundle-SymbolicName: com.liferay.petra.encryptor
 Bundle-Version: 1.0.0
 Export-Package: com.liferay.petra.encryptor
 Import-Package:\
-	com.ibm.*;resolution:=optional,\
+	com.ibm.crypto.provider;resolution:=optional,\
 	*
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title:

--- a/modules/apps/foundation/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspJavaFileObjectResolver.java
+++ b/modules/apps/foundation/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspJavaFileObjectResolver.java
@@ -163,7 +163,7 @@ public class JspJavaFileObjectResolver implements JavaFileObjectResolver {
 
 			fileName = url.getFile();
 
-			String protocol = "file:/";
+			String protocol = "file:";
 
 			int index = fileName.indexOf(protocol);
 

--- a/modules/apps/foundation/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspJavaFileObjectResolver.java
+++ b/modules/apps/foundation/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspJavaFileObjectResolver.java
@@ -188,9 +188,10 @@ public class JspJavaFileObjectResolver implements JavaFileObjectResolver {
 			if (index > 0) {
 				fileName = fileName.substring(0, index);
 			}
-		} else {
+		}
+		else {
 
-			// We don't know how to handle this kind of files; ignore them
+			// Ignore files that we do not know how to handle
 
 			return null;
 		}

--- a/modules/apps/foundation/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspJavaFileObjectResolver.java
+++ b/modules/apps/foundation/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspJavaFileObjectResolver.java
@@ -188,6 +188,11 @@ public class JspJavaFileObjectResolver implements JavaFileObjectResolver {
 			if (index > 0) {
 				fileName = fileName.substring(0, index);
 			}
+		} else {
+
+			// We don't know how to handle this kind of files; ignore them
+
+			return null;
 		}
 
 		return new File(URLCodec.decodeURL(fileName, StringPool.UTF8));
@@ -266,6 +271,14 @@ public class JspJavaFileObjectResolver implements JavaFileObjectResolver {
 		for (URL url : urls) {
 			try {
 				File file = getFile(url);
+
+				if (file == null) {
+					_logger.log(
+						Logger.LOG_WARNING,
+						"Ignoring " + url + " while handling system bundle");
+
+					continue;
+				}
 
 				try (FileSystem fileSystem = FileSystems.newFileSystem(
 						file.toPath(), null)) {

--- a/modules/apps/web-experience/asset/asset-publisher-web/build.gradle
+++ b/modules/apps/web-experience/asset/asset-publisher-web/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portlet.display.template", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.rss.util", version: "1.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "[2.0.0,2.4.0)"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.1.0"

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/toolbar/contributor/AssetPublisherPortletToolbarContributor.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/toolbar/contributor/AssetPublisherPortletToolbarContributor.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.asset.util.AssetUtil;
 
 import java.util.ArrayList;
@@ -112,7 +113,8 @@ public class AssetPublisherPortletToolbarContributor
 
 		if (!assetPublisherDisplayContext.isShowAddContentButton() ||
 			(scopeGroup == null) || scopeGroup.isLayoutPrototype() ||
-			(scopeGroup.hasStagingGroup() && !scopeGroup.isStagingGroup()) ||
+			(scopeGroup.hasStagingGroup() && !scopeGroup.isStagingGroup() &&
+			 !PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING) ||
 			portletName.equals(
 				AssetPublisherPortletKeys.HIGHEST_RATED_ASSETS) ||
 			portletName.equals(AssetPublisherPortletKeys.MOST_VIEWED_ASSETS) ||

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/toolbar/contributor/AssetPublisherPortletToolbarContributor.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/toolbar/contributor/AssetPublisherPortletToolbarContributor.java
@@ -114,7 +114,7 @@ public class AssetPublisherPortletToolbarContributor
 		if (!assetPublisherDisplayContext.isShowAddContentButton() ||
 			(scopeGroup == null) || scopeGroup.isLayoutPrototype() ||
 			(scopeGroup.hasStagingGroup() && !scopeGroup.isStagingGroup() &&
-			 !PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING) ||
+			 PropsValues.STAGING_LIVE_GROUP_LOCKING_ENABLED) ||
 			portletName.equals(
 				AssetPublisherPortletKeys.HIGHEST_RATED_ASSETS) ||
 			portletName.equals(AssetPublisherPortletKeys.MOST_VIEWED_ASSETS) ||

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/util/AssetPublisherUtil.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/util/AssetPublisherUtil.java
@@ -573,11 +573,21 @@ public class AssetPublisherUtil {
 				continue;
 			}
 
-			if (checkPermission &&
-				((!assetRenderer.isDisplayable() && !includeNonVisibleAssets) ||
-				 !assetRenderer.hasViewPermission(permissionChecker))) {
+			if (checkPermission) {
+				if (!assetRenderer.isDisplayable() &&
+					!includeNonVisibleAssets) {
 
-				continue;
+					continue;
+				}
+				else if (!assetRenderer.hasViewPermission(permissionChecker)) {
+					assetRenderer = assetRendererFactory.getAssetRenderer(
+						assetEntry.getClassPK(),
+						AssetRendererFactory.TYPE_LATEST_APPROVED);
+
+					if (!assetRenderer.hasViewPermission(permissionChecker)) {
+						continue;
+					}
+				}
 			}
 
 			assetEntries.add(assetEntry);

--- a/modules/apps/web-experience/export-import/export-import-service/build.gradle
+++ b/modules/apps/web-experience/export-import/export-import-service/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.background.task.service", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.3.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "com.thoughtworks.xstream", name: "xstream", version: "1.4.7"

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/staging/permission/StagingPermissionImpl.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/staging/permission/StagingPermissionImpl.java
@@ -76,7 +76,7 @@ public class StagingPermissionImpl implements StagingPermission {
 			long classPK, String portletId, String actionId)
 		throws Exception {
 
-		if (PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING) {
+		if (!PropsValues.STAGING_LIVE_GROUP_LOCKING_ENABLED) {
 			return null;
 		}
 

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/staging/permission/StagingPermissionImpl.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/staging/permission/StagingPermissionImpl.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PropsValues;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -74,6 +75,10 @@ public class StagingPermissionImpl implements StagingPermission {
 			PermissionChecker permissionChecker, Group group, String className,
 			long classPK, String portletId, String actionId)
 		throws Exception {
+
+		if (PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING) {
+			return null;
+		}
 
 		if (!actionId.equals(ActionKeys.ACCESS_IN_CONTROL_PANEL) &&
 			!actionId.equals(ActionKeys.ADD_TO_PAGE) &&

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5171,6 +5171,15 @@ public class JournalArticleLocalServiceImpl
 
 				addNewVersion = true;
 
+				JournalArticle liveArticle = fetchLatestArticleFromLive(
+					article);
+
+				if ((liveArticle != null) &&
+					(liveArticle.getVersion() > latestVersion)) {
+
+					latestVersion = liveArticle.getVersion();
+				}
+
 				version = MathUtil.format(latestVersion + 0.1, 1, 1);
 			}
 		}
@@ -5461,6 +5470,14 @@ public class JournalArticleLocalServiceImpl
 		Locale defaultLocale = getArticleDefaultLocale(content);
 
 		if (incrementVersion) {
+			JournalArticle liveArticle = fetchLatestArticleFromLive(oldArticle);
+
+			if ((liveArticle != null) &&
+				(liveArticle.getVersion() > oldVersion)) {
+
+				oldVersion = liveArticle.getVersion();
+			}
+
 			double newVersion = MathUtil.format(oldVersion + 0.1, 1, 1);
 
 			long id = counterLocalService.increment();
@@ -6439,6 +6456,31 @@ public class JournalArticleLocalServiceImpl
 		catch (DocumentException de) {
 			throw new SystemException(de);
 		}
+	}
+
+	protected JournalArticle fetchLatestArticleFromLive(JournalArticle article)
+		throws PortalException {
+
+		Group group = groupLocalService.getGroup(article.getGroupId());
+
+		long liveGroupId = group.getLiveGroupId();
+
+		if (liveGroupId == 0) {
+			return null;
+		}
+
+		JournalArticleResource articleResource =
+			journalArticleResourceLocalService.
+				fetchJournalArticleResourceByUuidAndGroupId(
+					article.getArticleResourceUuid(), liveGroupId);
+
+		if (articleResource == null) {
+			return null;
+		}
+
+		return journalArticleLocalService.fetchLatestArticle(
+			articleResource.getResourcePrimKey(), WorkflowConstants.STATUS_ANY,
+			false);
 	}
 
 	protected void format(

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7080,6 +7080,25 @@ public class JournalArticleLocalServiceImpl
 				groupId, JournalConstants.SERVICE_NAME));
 	}
 
+	protected double getNextVersion(JournalArticle article)
+		throws PortalException {
+
+		double nextVersion = article.getVersion();
+
+		// The next version must be greater than the version of the latest live
+		// article
+
+		JournalArticle latestLiveArticle = fetchLatestLiveArticle(article);
+
+		if ((latestLiveArticle != null) &&
+			(latestLiveArticle.getVersion() > nextVersion)) {
+
+			nextVersion = latestLiveArticle.getVersion();
+		}
+
+		return MathUtil.format(nextVersion + 0.1, 1, 1);
+	}
+
 	protected String getUniqueUrlTitle(
 			long id, long groupId, String articleId, String title)
 		throws PortalException {
@@ -7310,25 +7329,6 @@ public class JournalArticleLocalServiceImpl
 			JournalArticle.class.getName(), article.getResourcePrimKey());
 
 		subscriptionSender.flushNotificationsAsync();
-	}
-
-	protected double getNextVersion(JournalArticle article)
-		throws PortalException {
-
-		double nextVersion = article.getVersion();
-
-		// The next version must be greater than the version of the latest live
-		// article
-
-		JournalArticle latestLiveArticle = fetchLatestLiveArticle(article);
-
-		if ((latestLiveArticle != null) &&
-			(latestLiveArticle.getVersion() > nextVersion)) {
-
-			nextVersion = latestLiveArticle.getVersion();
-		}
-
-		return MathUtil.format(nextVersion + 0.1, 1, 1);
 	}
 
 	protected void saveImages(

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5171,7 +5171,7 @@ public class JournalArticleLocalServiceImpl
 
 				addNewVersion = true;
 
-				version = obtainNextVersionNumber(article);
+				version = getNextVersionNumber(article);
 			}
 		}
 
@@ -5461,7 +5461,7 @@ public class JournalArticleLocalServiceImpl
 		Locale defaultLocale = getArticleDefaultLocale(content);
 
 		if (incrementVersion) {
-			double newVersion = obtainNextVersionNumber(oldArticle);
+			double newVersion = getNextVersionNumber(oldArticle);
 
 			long id = counterLocalService.increment();
 
@@ -7312,7 +7312,7 @@ public class JournalArticleLocalServiceImpl
 		subscriptionSender.flushNotificationsAsync();
 	}
 
-	protected double obtainNextVersionNumber(JournalArticle article)
+	protected double getNextVersionNumber(JournalArticle article)
 		throws PortalException {
 
 		double oldVersion = article.getVersion();

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6441,7 +6441,7 @@ public class JournalArticleLocalServiceImpl
 		}
 	}
 
-	protected JournalArticle fetchLatestArticleFromLive(JournalArticle article)
+	protected JournalArticle fetchLatestLiveArticle(JournalArticle article)
 		throws PortalException {
 
 		Group group = groupLocalService.getGroup(article.getGroupId());
@@ -7320,7 +7320,7 @@ public class JournalArticleLocalServiceImpl
 		// The version must also higher than the live version of the article
 		// to avoid some versions not being published
 
-		JournalArticle liveArticle = fetchLatestArticleFromLive(article);
+		JournalArticle liveArticle = fetchLatestLiveArticle(article);
 
 		if ((liveArticle != null) && (liveArticle.getVersion() > oldVersion)) {
 			oldVersion = liveArticle.getVersion();

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6708,11 +6708,11 @@ public class JournalArticleLocalServiceImpl
 			if ((version > JournalArticleConstants.VERSION_DEFAULT) &&
 				incrementVersion) {
 
-				double oldVersion = MathUtil.format(version - 0.1, 1, 1);
-
 				long oldImageId = 0;
 
-				if ((oldVersion >= 1) && incrementVersion) {
+				if (incrementVersion) {
+					double oldVersion = getLatestVersion(groupId, articleId);
+
 					oldImageId =
 						journalArticleImageLocalService.getArticleImageId(
 							groupId, articleId, oldVersion, elInstanceId,

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5171,16 +5171,7 @@ public class JournalArticleLocalServiceImpl
 
 				addNewVersion = true;
 
-				JournalArticle liveArticle = fetchLatestArticleFromLive(
-					article);
-
-				if ((liveArticle != null) &&
-					(liveArticle.getVersion() > latestVersion)) {
-
-					latestVersion = liveArticle.getVersion();
-				}
-
-				version = MathUtil.format(latestVersion + 0.1, 1, 1);
+				version = obtainNextVersionNumber(article);
 			}
 		}
 
@@ -5470,15 +5461,7 @@ public class JournalArticleLocalServiceImpl
 		Locale defaultLocale = getArticleDefaultLocale(content);
 
 		if (incrementVersion) {
-			JournalArticle liveArticle = fetchLatestArticleFromLive(oldArticle);
-
-			if ((liveArticle != null) &&
-				(liveArticle.getVersion() > oldVersion)) {
-
-				oldVersion = liveArticle.getVersion();
-			}
-
-			double newVersion = MathUtil.format(oldVersion + 0.1, 1, 1);
+			double newVersion = obtainNextVersionNumber(oldArticle);
 
 			long id = counterLocalService.increment();
 
@@ -7327,6 +7310,23 @@ public class JournalArticleLocalServiceImpl
 			JournalArticle.class.getName(), article.getResourcePrimKey());
 
 		subscriptionSender.flushNotificationsAsync();
+	}
+
+	protected double obtainNextVersionNumber(JournalArticle article)
+		throws PortalException {
+
+		double oldVersion = article.getVersion();
+
+		// The version must also higher than the live version of the article
+		// to avoid some versions not being published
+
+		JournalArticle liveArticle = fetchLatestArticleFromLive(article);
+
+		if ((liveArticle != null) && (liveArticle.getVersion() > oldVersion)) {
+			oldVersion = liveArticle.getVersion();
+		}
+
+		return MathUtil.format(oldVersion + 0.1, 1, 1);
 	}
 
 	protected void saveImages(

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5171,7 +5171,7 @@ public class JournalArticleLocalServiceImpl
 
 				addNewVersion = true;
 
-				version = getNextVersionNumber(article);
+				version = getNextVersion(article);
 			}
 		}
 
@@ -5461,7 +5461,7 @@ public class JournalArticleLocalServiceImpl
 		Locale defaultLocale = getArticleDefaultLocale(content);
 
 		if (incrementVersion) {
-			double newVersion = getNextVersionNumber(oldArticle);
+			double newVersion = getNextVersion(oldArticle);
 
 			long id = counterLocalService.increment();
 
@@ -7312,7 +7312,7 @@ public class JournalArticleLocalServiceImpl
 		subscriptionSender.flushNotificationsAsync();
 	}
 
-	protected double getNextVersionNumber(JournalArticle article)
+	protected double getNextVersion(JournalArticle article)
 		throws PortalException {
 
 		double oldVersion = article.getVersion();

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7315,20 +7315,20 @@ public class JournalArticleLocalServiceImpl
 	protected double getNextVersion(JournalArticle article)
 		throws PortalException {
 
-		double oldVersion = article.getVersion();
+		double nextVersion = article.getVersion();
 
-		// The version must also higher than the live version of the article
-		// to avoid some versions not being published
+		// The next version must be greater than the version of the latest live
+		// article
 
 		JournalArticle latestLiveArticle = fetchLatestLiveArticle(article);
 
 		if ((latestLiveArticle != null) &&
-			(latestLiveArticle.getVersion() > oldVersion)) {
+			(latestLiveArticle.getVersion() > nextVersion)) {
 
-			oldVersion = latestLiveArticle.getVersion();
+			nextVersion = latestLiveArticle.getVersion();
 		}
 
-		return MathUtil.format(oldVersion + 0.1, 1, 1);
+		return MathUtil.format(nextVersion + 0.1, 1, 1);
 	}
 
 	protected void saveImages(

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7320,10 +7320,12 @@ public class JournalArticleLocalServiceImpl
 		// The version must also higher than the live version of the article
 		// to avoid some versions not being published
 
-		JournalArticle liveArticle = fetchLatestLiveArticle(article);
+		JournalArticle latestLiveArticle = fetchLatestLiveArticle(article);
 
-		if ((liveArticle != null) && (liveArticle.getVersion() > oldVersion)) {
-			oldVersion = liveArticle.getVersion();
+		if ((latestLiveArticle != null) &&
+			(latestLiveArticle.getVersion() > oldVersion)) {
+
+			oldVersion = latestLiveArticle.getVersion();
 		}
 
 		return MathUtil.format(oldVersion + 0.1, 1, 1);

--- a/modules/apps/web-experience/layout/layout-admin-web/build.gradle
+++ b/modules/apps/web-experience/layout/layout-admin-web/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.product.navigation.site.administration", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.site.api", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/control/menu/ToggleControlsProductNavigationControlMenuEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/control/menu/ToggleControlsProductNavigationControlMenuEntry.java
@@ -112,7 +112,7 @@ public class ToggleControlsProductNavigationControlMenuEntry
 		Group group = layout.getGroup();
 
 		if (group.hasStagingGroup() && !group.isStagingGroup() &&
-			!PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING) {
+			PropsValues.STAGING_LIVE_GROUP_LOCKING_ENABLED) {
 
 			return false;
 		}

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/control/menu/ToggleControlsProductNavigationControlMenuEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/control/menu/ToggleControlsProductNavigationControlMenuEntry.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.SessionClicks;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.product.navigation.control.menu.BaseProductNavigationControlMenuEntry;
 import com.liferay.product.navigation.control.menu.ProductNavigationControlMenuEntry;
 import com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuCategoryKeys;
@@ -110,7 +111,9 @@ public class ToggleControlsProductNavigationControlMenuEntry
 
 		Group group = layout.getGroup();
 
-		if (group.hasStagingGroup() && !group.isStagingGroup()) {
+		if (group.hasStagingGroup() && !group.isStagingGroup() &&
+			!PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING) {
+
 			return false;
 		}
 

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/customization_settings.jsp
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/customization_settings.jsp
@@ -56,7 +56,7 @@ Map<String, Object> data = new HashMap<>();
 data.put("qa-id", "customizations");
 %>
 
-<li class="active control-menu-link control-menu-nav-item customization-link">
+<li class="active control-menu-link control-menu-nav-item customization-link visible-xs">
 	<liferay-ui:icon
 		data="<%= data %>"
 		icon="pencil"

--- a/modules/apps/web-experience/staging/staging-bar-web/build.gradle
+++ b/modules/apps/web-experience/staging/staging-bar-web/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.staging.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.staging.lang", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"

--- a/modules/apps/web-experience/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/web-experience/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
@@ -72,6 +72,7 @@ page import="com.liferay.portal.kernel.util.comparator.LayoutRevisionCreateDateC
 page import="com.liferay.portal.kernel.util.comparator.LayoutRevisionIdComparator" %><%@
 page import="com.liferay.portal.kernel.workflow.WorkflowConstants" %><%@
 page import="com.liferay.portal.kernel.workflow.WorkflowTask" %><%@
+page import="com.liferay.portal.util.PropsValues" %><%@
 page import="com.liferay.staging.constants.StagingProcessesWebKeys" %>
 
 <%@ page import="java.util.ArrayList" %><%@

--- a/modules/apps/web-experience/staging/staging-bar-web/src/main/resources/META-INF/resources/last_publication_date_message.jsp
+++ b/modules/apps/web-experience/staging/staging-bar-web/src/main/resources/META-INF/resources/last_publication_date_message.jsp
@@ -119,7 +119,7 @@ if (Validator.isNull(publisherName)) {
 		</span>
 
 		<span class="staging-live-help">
-			<liferay-ui:message arguments="<%= HtmlUtil.escape(liveGroup.getDescriptiveName(locale)) %>" key='<%= (group.isStagingGroup() || group.isStagedRemotely()) ? "staging-staging-help-x" : PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING ? "staging-live-help2-x" : "staging-live-help-x" %>' translateArguments="<%= false %>" />
+			<liferay-ui:message arguments="<%= HtmlUtil.escape(liveGroup.getDescriptiveName(locale)) %>" key='<%= (group.isStagingGroup() || group.isStagedRemotely()) ? "staging-staging-help-x" : !PropsValues.STAGING_LIVE_GROUP_LOCKING_ENABLED ? "staging-live-help2-x" : "staging-live-help-x" %>' translateArguments="<%= false %>" />
 		</span>
 	</c:otherwise>
 </c:choose>

--- a/modules/apps/web-experience/staging/staging-bar-web/src/main/resources/META-INF/resources/last_publication_date_message.jsp
+++ b/modules/apps/web-experience/staging/staging-bar-web/src/main/resources/META-INF/resources/last_publication_date_message.jsp
@@ -119,7 +119,7 @@ if (Validator.isNull(publisherName)) {
 		</span>
 
 		<span class="staging-live-help">
-			<liferay-ui:message arguments="<%= HtmlUtil.escape(liveGroup.getDescriptiveName(locale)) %>" key='<%= (group.isStagingGroup() || group.isStagedRemotely()) ? "staging-staging-help-x" : "staging-live-help-x" %>' translateArguments="<%= false %>" />
+			<liferay-ui:message arguments="<%= HtmlUtil.escape(liveGroup.getDescriptiveName(locale)) %>" key='<%= (group.isStagingGroup() || group.isStagedRemotely()) ? "staging-staging-help-x" : PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING ? "staging-live-help2-x" : "staging-live-help-x" %>' translateArguments="<%= false %>" />
 		</span>
 	</c:otherwise>
 </c:choose>

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Staging Configuration
 staging-is-successfully-disabled=Staging is successfully disabled.
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public.
 staging-options=Staging Options
 staging-staging-help-x=You are viewing the staged version of <em>{0}</em>. You can make changes here and publish them to Live afterwards to make them public.
 staging-type=Staging Type

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_ar.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=انطلاق التكوين (Automatic Translation)
 staging-is-successfully-disabled=يتم تعطيل التدريج بنجاح. (Automatic Translation)
 staging-live-help-x=أنت تعرض نسخة البيئة المباشرة لـ <em>{0}</em> ولا يمكنك التغيير هنا. قم بالتغيير في التشغيل المرحلي ثم انشرها للبيئة المباشرة بعد ذلك لجعلها عامة.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=خيارات التدريج (Automatic Translation)
 staging-staging-help-x=أنت تعرض النسخة المرحلية لـ <em>{0}</em>. يمكنك التغيير هنا والنشر للبيئة المباشرة بعد ذلك لجعلها عامة.
 staging-type=نوع التشغيل المرحلي

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_bg.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Постановка конфигурация (Automatic Translation)
 staging-is-successfully-disabled=Постановка успешно е забранено. (Automatic Translation)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Постановка опции (Automatic Translation)
 staging-staging-help-x=You are viewing the staged version of <em>{0}</em>. You can make changes here and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-type=Staging Type (Automatic Copy)

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_ca.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Configuració de l'entorn de proves
 staging-is-successfully-disabled=Posada en escena és impossibilitat reeixidament. (Automatic Translation)
 staging-live-help-x=Aquesta és la versió activa de <em>{0}</em> i no podeu realitzar cap canvi. Introduïu els canvis a la versió de prova i publiqueu-los a Live.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Opcions de l'entorn de proves
 staging-staging-help-x=Aquest és el lloc de prova de <em>{0}</em>. Aquí es poden fer canvis per després publicar-los a Live.
 staging-type=Tipus d'escenaris en prova

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_cs.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Konfigurace pracovní (Automatic Translation)
 staging-is-successfully-disabled=Inscenace je úspěšně zakázána. (Automatic Translation)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Pracovní možnosti (Automatic Translation)
 staging-staging-help-x=Právě jste na přípravné stránce <em>{0}</em>. Změny, které zde provedete, můžete později uveřejnit do produkčního prostředí.
 staging-type=Typ přípravného prostředí

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_da.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Iscenesættelse konfiguration (Automatic Translation)
 staging-is-successfully-disabled=Staging is successfully disabled. (Automatic Copy)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public. (Automatic Copy)
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Midlertidige indstillinger (Automatic Translation)
 staging-staging-help-x=You are viewing the staged version of <em>{0}</em>. You can make changes here and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-type=Trinvis publicering Type

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_de.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Stagingkonfiguration
 staging-is-successfully-disabled=Staging wurde erfolgreich deaktiviert.
 staging-live-help-x=Sie sehen die Live-Version von <em>{0}</em>. Hier können keine Änderungen vorgenommen werden. Bitte nehmen Sie Ihre Änderungen im Stagingsystem vor und publizieren Sie diese danach, um sie zu veröffentlichen.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Stagingoptionen
 staging-staging-help-x=Sie betrachten die Stagingversion von <em>{0}</em>. Sie können hier Änderungen vornehmen und sie später publizieren, damit sie öffentlich verfügbar sind.
 staging-type=Stagingtyp

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_el.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Διαμόρφωση της στάσης (Automatic Translation)
 staging-is-successfully-disabled=Σταδιοποίηση με επιτυχία είναι απενεργοποιημένη. (Automatic Translation)
 staging-live-help-x=Βλέπετε την παραγωγική έκδοση του <em>{0}</em> και δεν μπορείτε να κάνετε αλλαγές εδώ. Κάνετε τις αλλαγές σας στο staging και έπειτα δημοσιεύστε τις για να μεταφερθούν στο παραγωγικό περιβάλλον.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Σταδιοποίηση επιλογές (Automatic Translation)
 staging-staging-help-x=Βλέπετε την έκδοση staging του <em>{0}</em>. Μπορείτε να κάνετε τις αλλαγές σας εδώ και έπειτα να τις δημοσιεύσετε παραγωγικό περιβάλλον.
 staging-type=Τύπος staging

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_en.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Staging Configuration
 staging-is-successfully-disabled=Staging is successfully disabled.
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public.
 staging-options=Staging Options
 staging-staging-help-x=You are viewing the staged version of <em>{0}</em>. You can make changes here and publish them to Live afterwards to make them public.
 staging-type=Staging Type

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_es.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Configuración de Staging
 staging-is-successfully-disabled=Puesta en escena con éxito está deshabilitado. (Automatic Translation)
 staging-live-help-x=Está accediendo a la versión live de <em>{0}</em> por tanto no puede realizar cambios desde aquí. Realícelos en staging y pubíquelos a Live para hacerlos públicos.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Opciones de Staging
 staging-staging-help-x=Éste es el sitio Staging de <em>{0}</em>. Aquí se pueden hacer cambios para luego publicarlos a Live.
 staging-type=Tipo de staging

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_et.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Lavastus konfiguratsiooni (Automatic Translation)
 staging-is-successfully-disabled=Lavastus on edukalt keelatud. (Automatic Translation)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public. (Automatic Copy)
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Lavastus Valikud (Automatic Translation)
 staging-staging-help-x=You are viewing the staged version of <em>{0}</em>. You can make changes here and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-type=Staging Type (Automatic Copy)

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_eu.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Staging Configuration (Automatic Copy)
 staging-is-successfully-disabled=Staging is successfully disabled. (Automatic Copy)
 staging-live-help-x=<em>{0}</em>-ren live bertsioa ikusten ari zara eta ezin duzu egin aldaketarik. Egin itzazu zure aldaketak eszenaratze ingurunean eta argitaratu hauek publiko egiteko.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Staging Options (Automatic Copy)
 staging-staging-help-x=<em>{0}</em>ren eszenaratutako bertsioa ikusten ari zara. Hemen aldaketak egin ahal ditzakezu eta ondoren publikatu Live ingurunera argitaratzeko.
 staging-type=Eskaerak

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_fa.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=پیکربندی مرحله‌بندی
 staging-is-successfully-disabled=شروع عملیات با موفقیت غیر فعال شده است. (Automatic Translation)
 staging-live-help-x=شما در حال مشاهده‌ی نسخه‌ی فعال <em>{0}</em> هستید و نمی‌توانید اینجا تغییراتی اعمال کنید. تغییرات را در مرحله‌بندی انجام داده و پس از اینکه آنها عمومی کردید انتشار دهید.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=گزینه‌های مرحله‌بندی
 staging-staging-help-x=شما در حال مشاهده نسخه مرحله بندی شده <em>{0}</em> هستید. شما می‌تواند تغییرات خود را اینجا انجام دهید و سپس آنها را در نسخه اجرایی منتشر کنید تا عمومی شوند.
 staging-type=نوع مرحله‌بندی

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_fi.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Vaiheistetunjulkaisun asetukset
 staging-is-successfully-disabled=Staging is successfully disabled. (Automatic Copy)
 staging-live-help-x=Katselet esitysveriota <em>{0}</em> ja et voi tehdä muutoksia sinne. Tee muutokset julkaisupuolella ja julkaise ne esityspuolelle jälkikäteen tehdäksesi ne julkisiksi.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Vaiheistetun julkaisun asetukset
 staging-staging-help-x=Katsot vaiheistettua versiota <em>{0}</em>. Voit tehdä muutoksia tänne ja julkaista ne jälkeenpäin julkiseksi.
 staging-type=Vaiheistetunjulkaisun tyyppi

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_fr.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Configuration de staging
 staging-is-successfully-disabled=Mise en scène est désactivé avec succès. (Automatic Translation)
 staging-live-help-x=Vous êtes en train de voir la version de production de <em>{0}</em> et vous ne pouvez pas faire des modifications ici. Effectuer les modification en staging et les publier vers production après pour les rendre publiques.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Options de staging
 staging-staging-help-x=Vous regardez la version en pré-production de <em>{0}</em>.Vous pouvez faire des changements ici et les publier en production après les avoir rendues publiques
 staging-type=Type de pré-production

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_gl.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Staging Configuration (Automatic Copy)
 staging-is-successfully-disabled=Staging is successfully disabled. (Automatic Copy)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Staging Options (Automatic Copy)
 staging-staging-help-x=You are viewing the staged version of <em>{0}</em>. You can make changes here and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-type=Tipo de fase

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_hi_IN.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=स्टैगिंग विन्यास (Automatic Translation)
 staging-is-successfully-disabled=स्टैगिंग सफलतापूर्वक अक्षम किया गया है। (Automatic Translation)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=स्टेजिंग विकल्पों (Automatic Translation)
 staging-staging-help-x=You are viewing the staged version of <em>{0}</em>. You can make changes here and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-type=मचान प्रकार (Automatic Translation)

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_hr.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Staging Configuration (Automatic Copy)
 staging-is-successfully-disabled=Staging is successfully disabled. (Automatic Copy)
 staging-live-help-x=Upravo gledate živu verziju <em>{0}</em> na kojoj nije moguće raditi promjene. Promjene napravite u staging okolini i potom ih objavite na živu verziju da bi postale javno dostupne.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Staging Options (Automatic Copy)
 staging-staging-help-x=You are viewing the staged version of <em>{0}</em>. You can make changes here and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-type=Vrsta inscenacije

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_hu.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Staging beállítás
 staging-is-successfully-disabled=Átmeneti sikeresen le van tiltva. (Automatic Translation)
 staging-live-help-x=A(z) <em>{0}</em> éles változatát látod. Itt nem lehet módosítani. Végezd el a módosításaidat a Többlépcsős munkafolyamatba szervezés alatt, és publikáld az élesre miután nyilvánossá tetted őket.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Staging opciók
 staging-staging-help-x=Jelenleg a következő oldal függő változata látható: <em>{0}</em>. Itt ez megváltoztatható, és az éles környezetbe nyilvánossá tétel után kerülhet át.
 staging-type=Többlépcsős munkafolyamat típusa

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_in.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Pementasan konfigurasi (Automatic Translation)
 staging-is-successfully-disabled=Pementasan berhasil dinonaktifkan. (Automatic Translation)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Pementasan pilihan (Automatic Translation)
 staging-staging-help-x=Anda melihat versi bertahap dari <em>{0}</em>. Anda dapat membuat perubahan di sini dan mempublikasikan mereka ke Hidup setelah itu untuk membuat mereka publik.
 staging-type=Tipe Staging

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_it.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Configurazione Staging
 staging-is-successfully-disabled=Messa in scena con successo è disabilitato. (Automatic Translation)
 staging-live-help-x=Stai visualizzando la versione live di <em>{0}</em> e non puoi effettuare modifiche. Effettua le modifiche nella versione di staging e pubblicale sulla versione Live per renderle pubbliche.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Opzioni di Staging
 staging-staging-help-x=Stai visualizzando la versione in staging di <em>{0}</em>. Puoi fare modifiche e pubblicarle in seguito sul sito Live per renderle pubbliche.
 staging-type=Tipo Staging

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_iw.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=תצוגת Staging
 staging-is-successfully-disabled=היערכות בהצלחה מושבתת. (Automatic Translation)
 staging-live-help-x=אתם צופים כעת בגירסה החיה של <em>{0}</em> ואינכם יכולים לערוך שינויים כאן. בצעו את השינויים שלכם ב-staging ופרסמו אותם אחר כך לחי כדי להפוך אותם לציבוריים.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=אפשרויות Staging
 staging-staging-help-x=אתה צופה כעת בגירסה המדורגת של <em>{0}</em>. באפשרותך לבצע כאן שינויים ולפרסם אותם אחר כך בלייב בכדי להפוך אותם לציבוריים.
 staging-type=סוג דירוג

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_ja.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=ステージング設定
 staging-is-successfully-disabled=Staging is successfully disabled. (Automatic Copy)
 staging-live-help-x=<em>{0}</em>のプロダクション環境が表示されています。そのためサイトへの変更はできません。変更をしたい場合はステージングで変更を行い、プロダクション環境に公開してください。
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=ステージングオプション
 staging-staging-help-x=<em>{0}</em>のステージングバージョンが表示されています。ここで変更して、プロダクション環境へ公開することができます。
 staging-type=ステージングタイプ

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_ko.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=준비 구성 (Automatic Translation)
 staging-is-successfully-disabled=준비는 성공적으로 사용할 수 없습니다. (Automatic Translation)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=준비 옵션 (Automatic Translation)
 staging-staging-help-x=You are viewing the staged version of <em>{0}</em>. You can make changes here and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-type=준비 단계 유형 (Automatic Translation)

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_lo.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Staging Configuration (Automatic Copy)
 staging-is-successfully-disabled=Staging is successfully disabled. (Automatic Copy)
 staging-live-help-x=ທ່ານກຳລັງເຮັດການແກ້ໄຂເວີເຊີ້ນທັນທີຂອງ <em>{0}</em> ແລະບໍ່ສາມາເຮັດການປ່ຽນແປງນະທີນີ້. ການເຮັດການປ່ຽນແປງໃນສະເຕ໋ກກິ້ງ ແລະເຜີຍແຜເປັນລາຍວ໌ກ່ອນເຮັດການເຜີຍແຜ່
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Staging Options (Automatic Copy)
 staging-staging-help-x=ທ່ານກຳລັງສະແດງເວີເຊີ້ນແທ໋ກຂອງ<em>{0}</em>. ທ່ານສາມາດເຮັດການປ່ຽນແປງຈາກທີ່ນີ້ ແລະ ເຜີຍແຜທັນທີເພື່ອເຮັດການເຜີຍແຜພວກມັນ
 staging-type=ຮູບແບບສະເຕ໋ກກິງ

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_lt.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Sustojimo konfigūracijos (Automatic Translation)
 staging-is-successfully-disabled=Sustojimo yra sėkmingai neįgaliesiems. (Automatic Translation)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public. (Automatic Copy)
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Sustojimo parinktys (Automatic Translation)
 staging-staging-help-x=You are viewing the staged version of <em>{0}</em>. You can make changes here and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-type=Staging Type (Automatic Copy)

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_nb.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Iscenesettelse konfigurasjon (Automatic Translation)
 staging-is-successfully-disabled=Iscenesettelse er deaktivert. (Automatic Translation)
 staging-live-help-x=Du ser på produksjonsversjonen av <em>{0}</em> og kan derfor ikke gjøre endringer her. Gjør endringene dine i testmiljøet og publiser dem til produksjonsmiljøet etterpå for å offentliggjøre dem.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Iscenesettelse alternativer (Automatic Translation)
 staging-staging-help-x=Du ser på testversjonen av <em>{0}</em>. Du kan gjøre endringer her og publisere dem til produksjonsmiljøet i etterkant for å offentliggjøre dem.
 staging-type=Testmiljøtype

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_nl.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Staging configuratie
 staging-is-successfully-disabled=Staging is successfully disabled. (Automatic Copy)
 staging-live-help-x=Dit is de productieversie van <em>{0}</em>. U kunt hier geen wijzigingen aanbrengen. Breng wijzigingen aan in de pre-publicatieomgeving en publiceer ze daarna naar productie om ze openbaar te maken.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Enscenering opties (Automatic Translation)
 staging-staging-help-x=Dit is de pre-publicatieversie van <em>{0}</em>. U kunt hier wijzigingen aanbrengen en ze daarna publiceren naar productie om ze openbaar te maken.
 staging-type=Type pre-publicatiefase

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_nl_BE.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Enscenering configuratie (Automatic Translation)
 staging-is-successfully-disabled=Staging is successfully disabled. (Automatic Copy)
 staging-live-help-x=Dit is de productieversie van <em>{0}</em>. U kunt hier geen veranderingen aanbrengen. Breng veranderingen aan in de pre-publicatieomgeving en publiceer ze daarna naar productie om ze openbaar te maken.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Enscenering opties (Automatic Translation)
 staging-staging-help-x=Dit is de pre-publicatieversie van <em>{0}</em>. U kunt hier veranderingen aanbrengen en ze daarna publiceren naar productie om ze openbaar te maken.
 staging-type=Publicatiefase type

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_pl.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Inscenizacja konfiguracji (Automatic Translation)
 staging-is-successfully-disabled=Inscenizacja jest pomyślnie wyłączona. (Automatic Translation)
 staging-live-help-x=Oglądasz wersję produkcyjną <em>{0}</em> i nie możesz robić w niej zmian. Wprowadzaj zmiany w środowisku testowym i potem publikuj je, aby stały się widoczne dla wszystkich.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Inscenizacja opcje (Automatic Translation)
 staging-staging-help-x=Oglądasz wersję testową <em>{0}</em>. Możesz tu wprowadzać zmiany i opublikować je do środowiska produkcyjnego po ich upublicznieniu.
 staging-type=Typ środowiska testowego

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_pt_BR.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Configuração de Staging
 staging-is-successfully-disabled=Encenação com êxito é desativada. (Automatic Translation)
 staging-live-help-x=Você está vendo a versão em produção de <em>{0}</em> e não pode fazer modificações aqui. Por favor, faça suas modificações em staging as publique para produção para torná-las públicas.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Opções de Staging
 staging-staging-help-x=Você está vendo a versão em staging de <em>{0}</em>. Você pode fazer alterações aqui e publicá-las em produção mais tarde para torná-las públicas.
 staging-type=Tipo de staging

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_pt_PT.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Configuração de Staging
 staging-is-successfully-disabled=Encenação com êxito é desativada. (Automatic Translation)
 staging-live-help-x=Está a ver a versão de produção (live) de <em>{0}</em> e não pode fazer alterações aqui. Por favor, faça as suas alterações em ambiente de staging e publique-as para produção (Live), para torná-las públicas.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Opções de Staging
 staging-staging-help-x=Está a ver a versão em staging de <em>{0}</em>. Pode fazer alterações aqui e publicá-las em produção mais tarde para torná-las públicas.
 staging-type=Tipo de Staging

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_ro.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Schela de configurare (Automatic Translation)
 staging-is-successfully-disabled=Stadializarea este dezactivat cu succes. (Automatic Translation)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Opţiuni de aşteptare (Automatic Translation)
 staging-staging-help-x=You are viewing the staged version of <em>{0}</em>. You can make changes here and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-type=Tip de Punere in Scena

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_ru.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Промежуточная Настройка (Automatic Translation)
 staging-is-successfully-disabled=Постановка успешно отключена. (Automatic Translation)
 staging-live-help-x=Вы видите действующую версию сайта <em>{0}</em> и не можете вносить изменения здесь. Сделайте ваши изменения в отладочном сайте и опубликуйте их на действующий, чтобы сделать их видимыми всем.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Варианты постановки (Automatic Translation)
 staging-staging-help-x=Вы видите отладочную версию сайта <em>{0}</em>. Вы можете вносить изменения здесь и опубликовать их на действующий, чтобы сделать изменения видимыми всем.
 staging-type=Тип отладочного сайта

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_sk.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Konfigurácia prípravy
 staging-is-successfully-disabled=Inscenácia sa úspešne vypol. (Automatic Translation)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Inscenácia možnosti (Automatic Translation)
 staging-staging-help-x=Práve vidíte prípravnú verziu <em>{0}</em>. Tu môžete robiť zmeny a potom ich zverejniť na produkčnom prostredí.
 staging-type=Typ prípravného prostredia

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_sl.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Uprizoritev konfiguracijo (Automatic Translation)
 staging-is-successfully-disabled=Uprizoritev je uspešno onemogočen. (Automatic Translation)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Uprizoritev možnosti (Automatic Translation)
 staging-staging-help-x=You are viewing the staged version of <em>{0}</em>. You can make changes here and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-type=Staging Type (Automatic Copy)

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_sr_RS.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Staging Configuration (Automatic Copy)
 staging-is-successfully-disabled=Staging is successfully disabled. (Automatic Copy)
 staging-live-help-x=Ви гледате уживо верзију <em>{0}</em> и не можете да направите промене овде. Направите промене у поставци и објавите их касније уживо да их јавно.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Staging Options (Automatic Copy)
 staging-staging-help-x=Ви гледате staged верзију <em>{0}</em>. Можете направити промене овде и објавите их касније уживо да их јавно.
 staging-type=Сценографија Тип

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Staging Configuration (Automatic Copy)
 staging-is-successfully-disabled=Staging is successfully disabled. (Automatic Copy)
 staging-live-help-x=Vi gledate uživo verziju <em>{0}</em> i ne možete da napravite promene ovde. Napravite promene u postavci i objavite ih kasnije uživo da ih javno.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Staging Options (Automatic Copy)
 staging-staging-help-x=Vi gledate staged verziju <em>{0}</em>. Možete napraviti promene ovde i objavite ih kasnije uživo da ih javno.
 staging-type=Scenografija Tip

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_sv.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Staging konfiguration (Automatic Translation)
 staging-is-successfully-disabled=Staging is successfully disabled. (Automatic Copy)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Staging alternativ (Automatic Translation)
 staging-staging-help-x=You are viewing the staged version of <em>{0}</em>. You can make changes here and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-type=Staging Type (Automatic Copy)

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_tr.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Hazırlama işlemi yapılandırma (Automatic Translation)
 staging-is-successfully-disabled=Hazırlama işlemi başarıyla devre dışı bırakıldı. (Automatic Translation)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Sınama seçenekleri (Automatic Translation)
 staging-staging-help-x=You are viewing the staged version of <em>{0}</em>. You can make changes here and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-type=Staging Type (Automatic Copy)

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_uk.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Постановка конфігурації (Automatic Translation)
 staging-is-successfully-disabled=Постановка успішно вимкнув. (Automatic Translation)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Постановка параметри (Automatic Translation)
 staging-staging-help-x=You are viewing the staged version of <em>{0}</em>. You can make changes here and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-type=Staging Type (Automatic Copy)

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_vi.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Dàn dựng cấu hình (Automatic Translation)
 staging-is-successfully-disabled=Dàn thành công vô hiệu hoá. (Automatic Translation)
 staging-live-help-x=You are viewing the live version of <em>{0}</em> and cannot make changes here. Make your changes in staging and publish them to Live afterwards to make them public.
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Dàn tùy chọn (Automatic Translation)
 staging-staging-help-x=Bạn đang xem một phiên bản chờ phổ biến của <em>{0}</em>. Bạn có thể thay đổi tại đây và xuất bản chúng tới phần trực tuyến sao đó mới có thể phổ biến.
 staging-type=Loại chưa sẵn sàng xuất bản

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_zh_CN.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=Staging配置
 staging-is-successfully-disabled=已成功禁用分期。 (Automatic Translation)
 staging-live-help-x=您正在查看<em>{0}</em>的在线版本，此处不允许改动。您可以在待发布阶段做改动，之后将其发布至在线，使其可见。
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=Staging选项
 staging-staging-help-x=您正在查看 <em>{0}</em>的待发布的版本。您可以在这做改动，之后将其发布至在线，使其成为公共的。
 staging-type=待发布类型

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_zh_TW.properties
@@ -132,6 +132,7 @@ staging-cannot-be-used-for-this-site-because-the-propagation-of-changes-from-the
 staging-configuration=階段中設置
 staging-is-successfully-disabled=已成功禁用分期。 (Automatic Translation)
 staging-live-help-x=您正檢視<em>{0}</em>的Live版本且不能在此產生修改。確認您的修改在階段中並能出版它們到Live以讓它們公開。
+staging-live-help2-x=You are viewing the live version of <em>{0}</em>. Make your changes here or in staging and publish them to Live afterwards to make them public. (Automatic Copy)
 staging-options=臨時選項 (Automatic Translation)
 staging-staging-help-x=您正在檢視<em>{0}</em>的階段版本。您能在產生修改並出版他們到Live以讓它們公開。
 staging-type=階段類型

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -1237,6 +1237,16 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 		accountLocalService.deleteAccount(company.getAccountId());
 
+		// Organizations
+
+		DeleteOrganizationActionableDynamicQuery
+			deleteOrganizationActionableDynamicQuery =
+				new DeleteOrganizationActionableDynamicQuery();
+
+		deleteOrganizationActionableDynamicQuery.setCompanyId(companyId);
+
+		deleteOrganizationActionableDynamicQuery.performActions();
+
 		// Groups
 
 		DeleteGroupActionableDynamicQuery deleteGroupActionableDynamicQuery =
@@ -1300,16 +1310,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			});
 
 		layoutSetPrototypeActionableDynamicQuery.performActions();
-
-		// Organizations
-
-		DeleteOrganizationActionableDynamicQuery
-			deleteOrganizationActionableDynamicQuery =
-				new DeleteOrganizationActionableDynamicQuery();
-
-		deleteOrganizationActionableDynamicQuery.setCompanyId(companyId);
-
-		deleteOrganizationActionableDynamicQuery.performActions();
 
 		// Roles
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
@@ -96,7 +96,7 @@ public class LayoutBranchLocalServiceImpl
 			layoutRevision.getLayoutSetBranchId(), layoutRevision.getPlid(),
 			name, description, master, serviceContext);
 
-		serviceContext.setAttribute("updateMajor", Boolean.TRUE.toString());
+		serviceContext.setAttribute("major", Boolean.TRUE.toString());
 
 		layoutRevisionLocalService.addLayoutRevision(
 			layoutBranch.getUserId(), layoutRevision.getLayoutSetBranchId(),

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutRevisionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutRevisionLocalServiceImpl.java
@@ -107,10 +107,9 @@ public class LayoutRevisionLocalServiceImpl
 
 		copyPortletPreferences(layoutRevision, portletPreferencesPlid);
 
-		boolean updateMajor = ParamUtil.getBoolean(
-			serviceContext, "updateMajor");
+		boolean major = ParamUtil.getBoolean(serviceContext, "major");
 
-		if (updateMajor || !isWorkflowEnabled(plid)) {
+		if (major || !isWorkflowEnabled(plid)) {
 			updateMajor(layoutRevision);
 		}
 
@@ -481,10 +480,9 @@ public class LayoutRevisionLocalServiceImpl
 			_layoutRevisionId.set(layoutRevision.getLayoutRevisionId());
 		}
 
-		boolean updateMajor = ParamUtil.getBoolean(
-			serviceContext, "updateMajor");
+		boolean major = ParamUtil.getBoolean(serviceContext, "major");
 
-		if (updateMajor || !isWorkflowEnabled(layoutRevision.getPlid())) {
+		if (major || !isWorkflowEnabled(layoutRevision.getPlid())) {
 			updateMajor(layoutRevision);
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetBranchLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetBranchLocalServiceImpl.java
@@ -144,7 +144,7 @@ public class LayoutSetBranchLocalServiceImpl
 
 		// Layout revisions
 
-		serviceContext.setAttribute("updateMajor", Boolean.TRUE.toString());
+		serviceContext.setAttribute("major", Boolean.TRUE.toString());
 
 		if (layoutSetBranch.isMaster() ||
 			(copyLayoutSetBranchId == LayoutSetBranchConstants.ALL_BRANCHES)) {

--- a/portal-impl/src/com/liferay/portal/service/permission/GroupPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/GroupPermissionImpl.java
@@ -90,7 +90,7 @@ public class GroupPermissionImpl
 		if ((actionId.equals(ActionKeys.ADD_LAYOUT) ||
 			 actionId.equals(ActionKeys.MANAGE_LAYOUTS)) &&
 			((group.hasLocalOrRemoteStagingGroup() &&
-			  !PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING) ||
+			  PropsValues.STAGING_LIVE_GROUP_LOCKING_ENABLED) ||
 			 group.isLayoutPrototype())) {
 
 			return false;

--- a/portal-impl/src/com/liferay/portal/service/permission/GroupPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/GroupPermissionImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
 import com.liferay.portal.kernel.service.permission.UserPermissionUtil;
 import com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties;
+import com.liferay.portal.util.PropsValues;
 
 /**
  * @author Brian Wing Shun Chan
@@ -88,7 +89,8 @@ public class GroupPermissionImpl
 
 		if ((actionId.equals(ActionKeys.ADD_LAYOUT) ||
 			 actionId.equals(ActionKeys.MANAGE_LAYOUTS)) &&
-			(group.hasLocalOrRemoteStagingGroup() ||
+			((group.hasLocalOrRemoteStagingGroup() &&
+			  !PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING) ||
 			 group.isLayoutPrototype())) {
 
 			return false;

--- a/portal-impl/src/com/liferay/portal/servlet/filters/aggregate/AggregateFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/aggregate/AggregateFilter.java
@@ -321,10 +321,16 @@ public class AggregateFilter extends IgnoreModuleRequestFilter {
 		cacheKeyGenerator.append(StringPool.UNDERLINE);
 		cacheKeyGenerator.append(request.getRequestURI());
 
-		String queryString = request.getQueryString();
+		String requestURL = String.valueOf(request.getRequestURL());
 
-		if (queryString != null) {
-			cacheKeyGenerator.append(sterilizeQueryString(queryString));
+		if (requestURL != null) {
+			requestURL = HttpUtil.removeParameter(requestURL, "zx");
+
+			String queryString = HttpUtil.getQueryString(requestURL);
+
+			if (queryString != null) {
+				cacheKeyGenerator.append(sterilizeQueryString(queryString));
+			}
 		}
 
 		return String.valueOf(cacheKeyGenerator.finish());

--- a/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSFilter.java
@@ -78,10 +78,16 @@ public class DynamicCSSFilter extends IgnoreModuleRequestFilter {
 		cacheKeyGenerator.append(StringPool.UNDERLINE);
 		cacheKeyGenerator.append(request.getRequestURI());
 
-		String queryString = request.getQueryString();
+		String requestURL = String.valueOf(request.getRequestURL());
 
-		if (queryString != null) {
-			cacheKeyGenerator.append(sterilizeQueryString(queryString));
+		if (requestURL != null) {
+			requestURL = HttpUtil.removeParameter(requestURL, "zx");
+
+			String queryString = HttpUtil.getQueryString(requestURL);
+
+			if (queryString != null) {
+				cacheKeyGenerator.append(sterilizeQueryString(queryString));
+			}
 		}
 
 		if (PortalUtil.isRightToLeft(request)) {

--- a/portal-impl/src/com/liferay/portal/tools/deploy/BaseDeployer.java
+++ b/portal-impl/src/com/liferay/portal/tools/deploy/BaseDeployer.java
@@ -764,9 +764,9 @@ public class BaseDeployer implements AutoDeployer, Deployer {
 
 			excludes += "/WEB-INF/web.xml";
 
-			WarTask.war(
-				srcFile, new File(tempDir, displayName + ".war"), excludes,
-				webXml);
+			File tempFile = new File(tempDir, displayName + ".war");
+
+			WarTask.war(srcFile, tempFile, excludes, webXml);
 
 			if (isJEEDeploymentEnabled()) {
 				File tempWarDir = new File(
@@ -789,7 +789,7 @@ public class BaseDeployer implements AutoDeployer, Deployer {
 				DeleteTask.deleteDirectory(tempWarDir);
 			}
 			else {
-				if (!tempDir.renameTo(deployDir)) {
+				if (!tempFile.renameTo(deployDir)) {
 					WarTask.war(srcFile, deployDir, excludes, webXml);
 				}
 

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1436,6 +1436,8 @@ public class PropsValues {
 
 	public static boolean STAGING_DELETE_TEMP_LAR_ON_SUCCESS = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.STAGING_DELETE_TEMP_LAR_ON_SUCCESS));
 
+	public static final boolean STAGING_DISABLE_LIVE_SITE_LOCKING = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.STAGING_DISABLE_LIVE_SITE_LOCKING));
+
 	public static int STAGING_DRAFT_EXPORT_IMPORT_CONFIGURATION_CHECK_INTERVAL = GetterUtil.getInteger(PropsUtil.get(PropsKeys.STAGING_DRAFT_EXPORT_IMPORT_CONFIGURATION_CHECK_INTERVAL));
 
 	public static int STAGING_DRAFT_EXPORT_IMPORT_CONFIGURATION_CLEAN_UP_COUNT = GetterUtil.getInteger(PropsUtil.get(PropsKeys.STAGING_DRAFT_EXPORT_IMPORT_CONFIGURATION_CLEAN_UP_COUNT));

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1436,11 +1436,11 @@ public class PropsValues {
 
 	public static boolean STAGING_DELETE_TEMP_LAR_ON_SUCCESS = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.STAGING_DELETE_TEMP_LAR_ON_SUCCESS));
 
-	public static final boolean STAGING_DISABLE_LIVE_SITE_LOCKING = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.STAGING_DISABLE_LIVE_SITE_LOCKING));
-
 	public static int STAGING_DRAFT_EXPORT_IMPORT_CONFIGURATION_CHECK_INTERVAL = GetterUtil.getInteger(PropsUtil.get(PropsKeys.STAGING_DRAFT_EXPORT_IMPORT_CONFIGURATION_CHECK_INTERVAL));
 
 	public static int STAGING_DRAFT_EXPORT_IMPORT_CONFIGURATION_CLEAN_UP_COUNT = GetterUtil.getInteger(PropsUtil.get(PropsKeys.STAGING_DRAFT_EXPORT_IMPORT_CONFIGURATION_CLEAN_UP_COUNT));
+
+	public static final boolean STAGING_LIVE_GROUP_LOCKING_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.STAGING_LIVE_GROUP_LOCKING_ENABLED));
 
 	public static boolean STAGING_LIVE_GROUP_REMOTE_STAGING_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.STAGING_LIVE_GROUP_REMOTE_STAGING_ENABLED));
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -439,29 +439,13 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		int[] statuses, int start, int end) {
 
 		try {
-			Indexer<?> indexer = AssetSearcher.getInstance();
-
-			AssetSearcher assetSearcher = (AssetSearcher)indexer;
-
-			AssetEntryQuery assetEntryQuery = new AssetEntryQuery();
-
-			assetEntryQuery.setClassNameIds(
-				getClassNameIds(companyId, className));
-
 			SearchContext searchContext = buildSearchContext(
 				companyId, groupIds, userId, classTypeId, null, null,
 				showNonindexable, statuses, false, start, end);
 
 			searchContext.setKeywords(keywords);
 
-			QueryConfig queryConfig = searchContext.getQueryConfig();
-
-			queryConfig.setHighlightEnabled(false);
-			queryConfig.setScoreEnabled(false);
-
-			assetSearcher.setAssetEntryQuery(assetEntryQuery);
-
-			return assetSearcher.search(searchContext);
+			return doSearch(companyId, className, searchContext);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -499,15 +483,6 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		int[] statuses, boolean andSearch, int start, int end) {
 
 		try {
-			Indexer<?> indexer = AssetSearcher.getInstance();
-
-			AssetSearcher assetSearcher = (AssetSearcher)indexer;
-
-			AssetEntryQuery assetEntryQuery = new AssetEntryQuery();
-
-			assetEntryQuery.setClassNameIds(
-				getClassNameIds(companyId, className));
-
 			SearchContext searchContext = buildSearchContext(
 				companyId, groupIds, userId, classTypeId, assetCategoryIds,
 				assetTagNames, showNonindexable, statuses, andSearch, start,
@@ -517,14 +492,7 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 			searchContext.setAttribute(Field.TITLE, title);
 			searchContext.setAttribute(Field.USER_NAME, userName);
 
-			QueryConfig queryConfig = searchContext.getQueryConfig();
-
-			queryConfig.setHighlightEnabled(false);
-			queryConfig.setScoreEnabled(false);
-
-			assetSearcher.setAssetEntryQuery(assetEntryQuery);
-
-			return assetSearcher.search(searchContext);
+			return doSearch(companyId, className, searchContext);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -1093,6 +1061,28 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		}
 
 		return categoryIds;
+	}
+
+	protected Hits doSearch(
+			long companyId, String className, SearchContext searchContext)
+		throws Exception {
+
+		QueryConfig queryConfig = searchContext.getQueryConfig();
+
+		queryConfig.setHighlightEnabled(false);
+		queryConfig.setScoreEnabled(false);
+
+		AssetEntryQuery assetEntryQuery = new AssetEntryQuery();
+
+		assetEntryQuery.setClassNameIds(getClassNameIds(companyId, className));
+
+		Indexer<?> indexer = AssetSearcher.getInstance();
+
+		AssetSearcher assetSearcher = (AssetSearcher)indexer;
+
+		assetSearcher.setAssetEntryQuery(assetEntryQuery);
+
+		return assetSearcher.search(searchContext);
 	}
 
 	protected AssetEntryQuery getAssetEntryQuery(

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -1067,18 +1067,18 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 			long companyId, String className, SearchContext searchContext)
 		throws Exception {
 
-		QueryConfig queryConfig = searchContext.getQueryConfig();
+		Indexer<?> indexer = AssetSearcher.getInstance();
 
-		queryConfig.setHighlightEnabled(false);
-		queryConfig.setScoreEnabled(false);
+		AssetSearcher assetSearcher = (AssetSearcher)indexer;
 
 		AssetEntryQuery assetEntryQuery = new AssetEntryQuery();
 
 		assetEntryQuery.setClassNameIds(getClassNameIds(companyId, className));
 
-		Indexer<?> indexer = AssetSearcher.getInstance();
+		QueryConfig queryConfig = searchContext.getQueryConfig();
 
-		AssetSearcher assetSearcher = (AssetSearcher)indexer;
+		queryConfig.setHighlightEnabled(false);
+		queryConfig.setScoreEnabled(false);
 
 		assetSearcher.setAssetEntryQuery(assetEntryQuery);
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -440,10 +440,8 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 		try {
 			SearchContext searchContext = buildSearchContext(
-				companyId, groupIds, userId, classTypeId, null, null,
+				companyId, groupIds, userId, classTypeId, keywords, null, null,
 				showNonindexable, statuses, false, start, end);
-
-			searchContext.setKeywords(keywords);
 
 			return doSearch(companyId, className, searchContext);
 		}
@@ -484,13 +482,9 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 		try {
 			SearchContext searchContext = buildSearchContext(
-				companyId, groupIds, userId, classTypeId, assetCategoryIds,
-				assetTagNames, showNonindexable, statuses, andSearch, start,
-				end);
-
-			searchContext.setAttribute(Field.DESCRIPTION, description);
-			searchContext.setAttribute(Field.TITLE, title);
-			searchContext.setAttribute(Field.USER_NAME, userName);
+				companyId, groupIds, userId, classTypeId, userName, title,
+				description, assetCategoryIds, assetTagNames, showNonindexable,
+				statuses, andSearch, start, end);
 
 			return doSearch(companyId, className, searchContext);
 		}
@@ -588,13 +582,9 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 				getClassNameIds(companyId, className));
 
 			SearchContext searchContext = buildSearchContext(
-				companyId, groupIds, userId, classTypeId, assetCategoryIds,
-				assetTagNames, showNonindexable, statuses, andSearch,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-			searchContext.setAttribute(Field.DESCRIPTION, description);
-			searchContext.setAttribute(Field.TITLE, title);
-			searchContext.setAttribute(Field.USER_NAME, userName);
+				companyId, groupIds, userId, classTypeId, userName, title,
+				description, assetCategoryIds, assetTagNames, showNonindexable,
+				statuses, andSearch, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 			QueryConfig queryConfig = searchContext.getQueryConfig();
 
@@ -1031,6 +1021,38 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		searchContext.setGroupIds(groupIds);
 		searchContext.setStart(start);
 		searchContext.setUserId(userId);
+
+		return searchContext;
+	}
+
+	protected SearchContext buildSearchContext(
+		long companyId, long[] groupIds, long userId, long classTypeId,
+		String keywords, String assetCategoryIds, String assetTagNames,
+		boolean showNonindexable, int[] statuses, boolean andSearch, int start,
+		int end) {
+
+		SearchContext searchContext = buildSearchContext(
+			companyId, groupIds, userId, classTypeId, assetCategoryIds,
+			assetTagNames, showNonindexable, statuses, andSearch, start, end);
+
+		searchContext.setKeywords(keywords);
+
+		return searchContext;
+	}
+
+	protected SearchContext buildSearchContext(
+		long companyId, long[] groupIds, long userId, long classTypeId,
+		String userName, String title, String description,
+		String assetCategoryIds, String assetTagNames, boolean showNonindexable,
+		int[] statuses, boolean andSearch, int start, int end) {
+
+		SearchContext searchContext = buildSearchContext(
+			companyId, groupIds, userId, classTypeId, assetCategoryIds,
+			assetTagNames, showNonindexable, statuses, andSearch, start, end);
+
+		searchContext.setAttribute(Field.DESCRIPTION, description);
+		searchContext.setAttribute(Field.TITLE, title);
+		searchContext.setAttribute(Field.USER_NAME, userName);
 
 		return searchContext;
 	}

--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetSearcher.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetSearcher.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
@@ -69,6 +70,32 @@ public class AssetSearcher extends BaseSearcher {
 		}
 
 		return classNames;
+	}
+
+	@Override
+	public void postProcessSearchQuery(
+			BooleanQuery searchQuery, BooleanFilter fullQueryBooleanFilter,
+			SearchContext searchContext)
+		throws Exception {
+
+		String keywords = searchContext.getKeywords();
+
+		if (Validator.isNull(keywords)) {
+			addSearchTerm(searchQuery, searchContext, Field.DESCRIPTION, false);
+			addSearchTerm(searchQuery, searchContext, Field.TITLE, false);
+			addSearchTerm(searchQuery, searchContext, Field.USER_NAME, false);
+		}
+		else {
+			for (String entryClassName : searchContext.getEntryClassNames()) {
+				Indexer<?> indexer = IndexerRegistryUtil.getIndexer(
+					entryClassName);
+
+				if (Validator.isNotNull(indexer)) {
+					indexer.postProcessSearchQuery(
+						searchQuery, fullQueryBooleanFilter, searchContext);
+				}
+			}
+		}
 	}
 
 	public void setAssetEntryQuery(AssetEntryQuery assetEntryQuery) {

--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetSearcher.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetSearcher.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Indexer;
-import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
@@ -70,32 +69,6 @@ public class AssetSearcher extends BaseSearcher {
 		}
 
 		return classNames;
-	}
-
-	@Override
-	public void postProcessSearchQuery(
-			BooleanQuery searchQuery, BooleanFilter fullQueryBooleanFilter,
-			SearchContext searchContext)
-		throws Exception {
-
-		String keywords = searchContext.getKeywords();
-
-		if (Validator.isNull(keywords)) {
-			addSearchTerm(searchQuery, searchContext, Field.DESCRIPTION, false);
-			addSearchTerm(searchQuery, searchContext, Field.TITLE, false);
-			addSearchTerm(searchQuery, searchContext, Field.USER_NAME, false);
-
-			return;
-		}
-
-		for (String entryClassName : searchContext.getEntryClassNames()) {
-			Indexer<?> indexer = IndexerRegistryUtil.getIndexer(entryClassName);
-
-			if (indexer != null) {
-				indexer.postProcessSearchQuery(
-					searchQuery, fullQueryBooleanFilter, searchContext);
-			}
-		}
 	}
 
 	public void setAssetEntryQuery(AssetEntryQuery assetEntryQuery) {

--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetSearcher.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetSearcher.java
@@ -84,16 +84,16 @@ public class AssetSearcher extends BaseSearcher {
 			addSearchTerm(searchQuery, searchContext, Field.DESCRIPTION, false);
 			addSearchTerm(searchQuery, searchContext, Field.TITLE, false);
 			addSearchTerm(searchQuery, searchContext, Field.USER_NAME, false);
-		}
-		else {
-			for (String entryClassName : searchContext.getEntryClassNames()) {
-				Indexer<?> indexer = IndexerRegistryUtil.getIndexer(
-					entryClassName);
 
-				if (Validator.isNotNull(indexer)) {
-					indexer.postProcessSearchQuery(
-						searchQuery, fullQueryBooleanFilter, searchContext);
-				}
+			return;
+		}
+
+		for (String entryClassName : searchContext.getEntryClassNames()) {
+			Indexer<?> indexer = IndexerRegistryUtil.getIndexer(entryClassName);
+
+			if (indexer != null) {
+				indexer.postProcessSearchQuery(
+					searchQuery, fullQueryBooleanFilter, searchContext);
 			}
 		}
 	}

--- a/portal-impl/src/com/liferay/portlet/asset/util/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/asset/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.2
+version 1.1.0

--- a/portal-impl/src/com/liferay/portlet/asset/util/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/asset/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.0.2

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/display/context/GroupDisplayContextHelper.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/display/context/GroupDisplayContextHelper.java
@@ -39,7 +39,7 @@ public class GroupDisplayContextHelper {
 			return _group;
 		}
 
-		if (PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING &&
+		if (!PropsValues.STAGING_LIVE_GROUP_LOCKING_ENABLED &&
 			(getSelGroup() != null)) {
 
 			_group = getSelGroup();

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/display/context/GroupDisplayContextHelper.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/display/context/GroupDisplayContextHelper.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.util.PropsValues;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -38,7 +39,12 @@ public class GroupDisplayContextHelper {
 			return _group;
 		}
 
-		if (getStagingGroup() != null) {
+		if (PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING &&
+			(getSelGroup() != null)) {
+
+			_group = getSelGroup();
+		}
+		else if (getStagingGroup() != null) {
 			_group = getStagingGroup();
 		}
 		else {

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6514,7 +6514,7 @@
         # Dynamic References
         #
         \
-        com.ibm.*,\
+        com.ibm.crypto.provider,\
         com.mysql.jdbc,\
         com.sun.security.auth.module,\
         org.apache.naming.java,\

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7250,7 +7250,7 @@
     staging.delete.temp.lar.on.success=true
 
     #
-    # Set this to false to enable editing on the live site.
+    # Set this property to false to enable editing on the live site.
     #
     staging.live.group.locking.enabled=true
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7250,9 +7250,9 @@
     staging.delete.temp.lar.on.success=true
 
     #
-    # Set this to true to enable editing on the live site.
+    # Set this to false to enable editing on the live site.
     #
-    staging.disable.live.site.locking=false
+    staging.live.group.locking.enabled=true
 
     #
     # By default, in a remote staging environment, the live group is marked and

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7250,6 +7250,11 @@
     staging.delete.temp.lar.on.success=true
 
     #
+    # Set this to true to enable editing on the live site.
+    #
+    staging.disable.live.site.locking=false
+
+    #
     # By default, in a remote staging environment, the live group is marked and
     # staging is prevented on the live group.
     #

--- a/portal-impl/test/integration/com/liferay/portal/service/CompanyLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/CompanyLocalServiceTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.OrganizationConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
@@ -258,6 +259,40 @@ public class CompanyLocalServiceTest {
 		group = GroupLocalServiceUtil.fetchGroup(group.getGroupId());
 
 		Assert.assertNull(group);
+	}
+
+	@Test
+	public void testAddAndDeleteCompanyWithStagedOrganizationSite()
+		throws Exception {
+
+		Company company = addCompany();
+
+		long companyId = company.getCompanyId();
+
+		User companyAdminUser = UserTestUtil.addCompanyAdminUser(company);
+
+		Organization companyOrganzation =
+			OrganizationLocalServiceUtil.addOrganization(
+				companyAdminUser.getUserId(),
+				OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID,
+				RandomTestUtil.randomString(), true);
+
+		Group companyOrganizationGroup = companyOrganzation.getGroup();
+
+		GroupTestUtil.enableLocalStaging(
+			companyOrganizationGroup, companyAdminUser.getUserId());
+
+		CompanyLocalServiceUtil.deleteCompany(company);
+
+		companyOrganzation = OrganizationLocalServiceUtil.fetchOrganization(
+			companyOrganzation.getOrganizationId());
+
+		Assert.assertNull(companyOrganzation);
+
+		companyOrganizationGroup = GroupLocalServiceUtil.fetchGroup(
+			companyOrganizationGroup.getGroupId());
+
+		Assert.assertNull(companyOrganizationGroup);
 	}
 
 	@Test

--- a/portal-kernel/src/com/liferay/asset/kernel/model/BaseAssetRenderer.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/BaseAssetRenderer.java
@@ -27,10 +27,13 @@ import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
@@ -219,7 +222,7 @@ public abstract class BaseAssetRenderer<T> implements AssetRenderer<T> {
 			group = layout.getGroup();
 		}
 
-		if (group.hasStagingGroup()) {
+		if (group.hasStagingGroup() && !_STAGING_DISABLE_LIVE_SITE_LOCKING) {
 			return null;
 		}
 
@@ -425,6 +428,10 @@ public abstract class BaseAssetRenderer<T> implements AssetRenderer<T> {
 	}
 
 	private static final String[] _AVAILABLE_LANGUAGE_IDS = new String[0];
+
+	private static final boolean _STAGING_DISABLE_LIVE_SITE_LOCKING =
+		GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.STAGING_DISABLE_LIVE_SITE_LOCKING));
 
 	private static final DDMFormValuesReader _nullDDMFormValuesReader =
 		new NullDDMFormValuesReader();

--- a/portal-kernel/src/com/liferay/asset/kernel/model/BaseAssetRenderer.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/BaseAssetRenderer.java
@@ -222,7 +222,7 @@ public abstract class BaseAssetRenderer<T> implements AssetRenderer<T> {
 			group = layout.getGroup();
 		}
 
-		if (group.hasStagingGroup() && !_STAGING_DISABLE_LIVE_SITE_LOCKING) {
+		if (group.hasStagingGroup() && _STAGING_LIVE_GROUP_LOCKING_ENABLED) {
 			return null;
 		}
 
@@ -429,9 +429,9 @@ public abstract class BaseAssetRenderer<T> implements AssetRenderer<T> {
 
 	private static final String[] _AVAILABLE_LANGUAGE_IDS = new String[0];
 
-	private static final boolean _STAGING_DISABLE_LIVE_SITE_LOCKING =
+	private static final boolean _STAGING_LIVE_GROUP_LOCKING_ENABLED =
 		GetterUtil.getBoolean(
-			PropsUtil.get(PropsKeys.STAGING_DISABLE_LIVE_SITE_LOCKING));
+			PropsUtil.get(PropsKeys.STAGING_LIVE_GROUP_LOCKING_ENABLED));
 
 	private static final DDMFormValuesReader _nullDDMFormValuesReader =
 		new NullDDMFormValuesReader();

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2091,6 +2091,8 @@ public interface PropsKeys {
 
 	public static final String STAGING_DELETE_TEMP_LAR_ON_SUCCESS = "staging.delete.temp.lar.on.success";
 
+	public static final String STAGING_DISABLE_LIVE_SITE_LOCKING = "staging.disable.live.site.locking";
+
 	public static final String STAGING_DRAFT_EXPORT_IMPORT_CONFIGURATION_CHECK_INTERVAL = "staging.draft.export.import.configuration.check.interval";
 
 	public static final String STAGING_DRAFT_EXPORT_IMPORT_CONFIGURATION_CLEAN_UP_COUNT = "staging.draft.export.import.configuration.clean.up.count";

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2091,11 +2091,11 @@ public interface PropsKeys {
 
 	public static final String STAGING_DELETE_TEMP_LAR_ON_SUCCESS = "staging.delete.temp.lar.on.success";
 
-	public static final String STAGING_DISABLE_LIVE_SITE_LOCKING = "staging.disable.live.site.locking";
-
 	public static final String STAGING_DRAFT_EXPORT_IMPORT_CONFIGURATION_CHECK_INTERVAL = "staging.draft.export.import.configuration.check.interval";
 
 	public static final String STAGING_DRAFT_EXPORT_IMPORT_CONFIGURATION_CLEAN_UP_COUNT = "staging.draft.export.import.configuration.clean.up.count";
+
+	public static final String STAGING_LIVE_GROUP_LOCKING_ENABLED = "staging.live.group.locking.enabled";
 
 	public static final String STAGING_LIVE_GROUP_REMOTE_STAGING_ENABLED = "staging.live.group.remote.staging.enabled";
 

--- a/portal-test/src/com/liferay/portal/kernel/test/util/GroupTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/GroupTestUtil.java
@@ -161,6 +161,12 @@ public class GroupTestUtil {
 	}
 
 	public static void enableLocalStaging(Group group) throws Exception {
+		enableLocalStaging(group, TestPropsValues.getUserId());
+	}
+
+	public static void enableLocalStaging(Group group, long userId)
+		throws Exception {
+
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext();
 
@@ -184,7 +190,7 @@ public class GroupTestUtil {
 		}
 
 		StagingLocalServiceUtil.enableLocalStaging(
-			TestPropsValues.getUserId(), group, false, false, serviceContext);
+			userId, group, false, false, serviceContext);
 	}
 
 	public static Group updateDisplaySettings(

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -64,7 +64,7 @@ if (layout != null) {
 }
 %>
 
-<c:if test="<%= !themeDisplay.isStatePopUp() && !group.isControlPanel() && (layout != null) && (!group.hasStagingGroup() || group.isStagingGroup() || PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING || layoutTypePortlet.isCustomizable()) && (GroupPermissionUtil.contains(permissionChecker, scopeGroupId, ActionKeys.ADD_LAYOUT) || LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.UPDATE) || (layoutTypePortlet.isCustomizable() && LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.CUSTOMIZE))) %>">
+<c:if test="<%= !themeDisplay.isStatePopUp() && !group.isControlPanel() && (layout != null) && (!group.hasStagingGroup() || group.isStagingGroup() || !PropsValues.STAGING_LIVE_GROUP_LOCKING_ENABLED || layoutTypePortlet.isCustomizable()) && (GroupPermissionUtil.contains(permissionChecker, scopeGroupId, ActionKeys.ADD_LAYOUT) || LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.UPDATE) || (layoutTypePortlet.isCustomizable() && LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.CUSTOMIZE))) %>">
 	<c:if test="<%= layout.isTypePortlet() %>">
 		<aui:script position="inline">
 			Liferay.Data.layoutConfig = {

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -64,7 +64,7 @@ if (layout != null) {
 }
 %>
 
-<c:if test="<%= !themeDisplay.isStatePopUp() && !group.isControlPanel() && (layout != null) && (!group.hasStagingGroup() || group.isStagingGroup() || layoutTypePortlet.isCustomizable()) && (GroupPermissionUtil.contains(permissionChecker, scopeGroupId, ActionKeys.ADD_LAYOUT) || LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.UPDATE) || (layoutTypePortlet.isCustomizable() && LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.CUSTOMIZE))) %>">
+<c:if test="<%= !themeDisplay.isStatePopUp() && !group.isControlPanel() && (layout != null) && (!group.hasStagingGroup() || group.isStagingGroup() || PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING || layoutTypePortlet.isCustomizable()) && (GroupPermissionUtil.contains(permissionChecker, scopeGroupId, ActionKeys.ADD_LAYOUT) || LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.UPDATE) || (layoutTypePortlet.isCustomizable() && LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.CUSTOMIZE))) %>">
 	<c:if test="<%= layout.isTypePortlet() %>">
 		<aui:script position="inline">
 			Liferay.Data.layoutConfig = {

--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -190,7 +190,7 @@ if ((portletParallelRender != null) && (portletParallelRender.booleanValue() == 
 
 Layout curLayout = PortletConfigurationLayoutUtil.getLayout(themeDisplay);
 
-if ((!group.hasStagingGroup() || group.isStagingGroup() || PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING) &&
+if ((!group.hasStagingGroup() || group.isStagingGroup() || !PropsValues.STAGING_LIVE_GROUP_LOCKING_ENABLED) &&
 	(PortletPermissionUtil.contains(permissionChecker, themeDisplay.getScopeGroupId(), curLayout, portlet, ActionKeys.CONFIGURATION))) {
 
 	showConfigurationIcon = true;
@@ -262,7 +262,7 @@ if (responseContentType.equals(ContentTypes.XHTML_MP) && portlet.hasMultipleMime
 // staging is activated, only staging layouts can be updated.
 
 if ((!themeDisplay.isSignedIn()) ||
-	(group.hasStagingGroup() && !group.isStagingGroup() && !PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING) ||
+	(group.hasStagingGroup() && !group.isStagingGroup() && PropsValues.STAGING_LIVE_GROUP_LOCKING_ENABLED) ||
 	(!LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.UPDATE))) {
 
 	if (!(!columnDisabled && customizable && LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.CUSTOMIZE))) {

--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -190,7 +190,7 @@ if ((portletParallelRender != null) && (portletParallelRender.booleanValue() == 
 
 Layout curLayout = PortletConfigurationLayoutUtil.getLayout(themeDisplay);
 
-if ((!group.hasStagingGroup() || group.isStagingGroup()) &&
+if ((!group.hasStagingGroup() || group.isStagingGroup() || PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING) &&
 	(PortletPermissionUtil.contains(permissionChecker, themeDisplay.getScopeGroupId(), curLayout, portlet, ActionKeys.CONFIGURATION))) {
 
 	showConfigurationIcon = true;
@@ -262,7 +262,7 @@ if (responseContentType.equals(ContentTypes.XHTML_MP) && portlet.hasMultipleMime
 // staging is activated, only staging layouts can be updated.
 
 if ((!themeDisplay.isSignedIn()) ||
-	(group.hasStagingGroup() && !group.isStagingGroup()) ||
+	(group.hasStagingGroup() && !group.isStagingGroup() && !PropsValues.STAGING_DISABLE_LIVE_SITE_LOCKING) ||
 	(!LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.UPDATE))) {
 
 	if (!(!columnDisabled && customizable && LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.CUSTOMIZE))) {

--- a/util-taglib/bnd.bnd
+++ b/util-taglib/bnd.bnd
@@ -13,6 +13,8 @@ Import-Package:\
 	\
 	!org.json.*,\
 	\
+	com.ibm.crypto.provider;resolution:=optional,\
+	\
 	com.liferay.*,\
 	*
 Include-Resource:\


### PR DESCRIPTION
Hey Jon,

Attached is another update for https://issues.liferay.com/browse/LPS-65343.

This is in addition to this commit: 2e5fd81ddaa5bbeedce815bd2fe1cd2e276e9c76.

The addition of the 'zx' random param by senna was causing every css request to be minified again instead of using the cached version.  These changes remove that param when checking for it in the cache.

I'm not a huge fan of the fact that with these changes there is now the string "zx" hard coded in three places, but I don't see a good place to create a constant for this.

Please let me know if there are any issues.

Thanks!