### PR TITLE
LPS-65780 - SPA - portlet blacklist and valid status codes are sometimes not set

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/foundation/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/init.jsp
@@ -27,15 +27,19 @@ SPAUtil spaUtil = (SPAUtil)request.getAttribute(SPAWebKeys.SPA_UTIL);
 %>
 
 <aui:script require="frontend-js-spa-web/liferay/init.es">
-	Liferay.on(
-		'SPAReady',
-		function() {
-			var app = Liferay.SPA.app;
+	var setSPAProperties = function() {
+		var app = Liferay.SPA.app;
 
-			app.setPortletsBlacklist(<%= spaUtil.getPortletsBlacklist(themeDisplay) %>);
-			app.setValidStatusCodes(<%= spaUtil.getValidStatusCodes() %>);
-		}
-	);
+		app.setPortletsBlacklist(<%= spaUtil.getPortletsBlacklist(themeDisplay) %>);
+		app.setValidStatusCodes(<%= spaUtil.getValidStatusCodes() %>);
+	};
+
+	if (Liferay.SPA.app == null) {
+		Liferay.on('SPAReady', setSPAProperties);
+	}
+	else {
+		setSPAProperties();
+	}
 </aui:script>
 
 <aui:script>


### PR DESCRIPTION
Hey Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-65780.

This was caused by some changes I made in [LPS-65551](https://issues.liferay.com/browse/LPS-65551).

This now should account for whichever code runs first between init.jsp and init.es.js.

Please let me know if there are any issues.

Thanks!