### PR TITLE
LPS-65672 - Unable to close the info panel on mobile devices when an asset is selected

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel.jsp
@@ -124,9 +124,6 @@ if (ListUtil.isEmpty(folders) && ListUtil.isEmpty(fileEntries) && ListUtil.isEmp
 				<li>
 					<liferay-util:include page="/document_library/file_entry_action.jsp" servletContext="<%= application %>" />
 				</li>
-				<li>
-					<aui:icon cssClass="icon-monospaced sidenav-close visible-xs-block" data="<%= infoPanelToggleData %>" image="times" markupView="lexicon" url="javascript:;" />
-				</li>
 			</ul>
 
 			<h4><%= HtmlUtil.escape(fileEntry.getTitle()) %></h4>
@@ -306,9 +303,6 @@ if (ListUtil.isEmpty(folders) && ListUtil.isEmpty(fileEntries) && ListUtil.isEmp
 				<li>
 					<liferay-util:include page="/document_library/file_entry_action.jsp" servletContext="<%= application %>" />
 				</li>
-				<li>
-					<aui:icon cssClass="icon-monospaced sidenav-close visible-xs-block" data="<%= infoPanelToggleData %>" image="times" markupView="lexicon" url="javascript:;" />
-				</li>
 			</ul>
 
 			<h4><%= HtmlUtil.escape(fileShortcut.getToTitle()) %></h4>
@@ -424,9 +418,6 @@ if (ListUtil.isEmpty(folders) && ListUtil.isEmpty(fileEntries) && ListUtil.isEmp
 			<ul class="list-inline list-unstyled">
 				<li>
 					<h4><liferay-ui:message arguments="<%= folders.size() + fileEntries.size() %>" key="x-items-selected" /></h4>
-				</li>
-				<li>
-					<aui:icon cssClass="icon-monospaced sidenav-close visible-xs-block" data="<%= infoPanelToggleData %>" image="times" markupView="lexicon" url="javascript:;" />
 				</li>
 			</ul>
 		</div>

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/sidebar_panel/end.jsp
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/sidebar_panel/end.jsp
@@ -16,6 +16,7 @@
 
 <%@ include file="/sidebar_panel/init.jsp" %>
 
+		</div>
 	</div>
 </div>
 

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/sidebar_panel/start.jsp
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/sidebar_panel/start.jsp
@@ -17,5 +17,6 @@
 <%@ include file="/sidebar_panel/init.jsp" %>
 
 <div class="sidenav-menu-slider">
-	<div class="sidebar sidebar-default sidenav-menu" id="<%= namespace %>sidebarPanel">
+	<div class="sidebar sidebar-default sidenav-menu">
 		<aui:icon cssClass="icon-monospaced pull-right sidenav-close text-default visible-xs-block" image="times" markupView="lexicon" url="javascript:;" />
+		<div id="<%= namespace %>sidebarPanel">


### PR DESCRIPTION
Hey Jon,

Attached is an upate for https://issues.liferay.com/browse/LPS-65672.

I changed the structure in the sidebar panel taglib so that the close button won't be overwritten in [`sidebar_panel.js` ](https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/sidebar_panel/js/sidebar_panel.js#L74).

I also removed some duplicate side panel close buttons from in document library.

Please let me know if there are any issues.

Thanks!