### PR TITLE
[Technical Support] LPS-67718

### DIFF
--- a/modules/apps/web-experience/layout/layout-taglib/src/main/resources/META-INF/resources/layouts_tree/js/layouts_tree_state.js
+++ b/modules/apps/web-experience/layout/layout-taglib/src/main/resources/META-INF/resources/layouts_tree/js/layouts_tree_state.js
@@ -113,7 +113,7 @@ AUI.add(
 						}
 
 						if (!Lang.isUndefined(checked)) {
-							instance._updateCheckedNodes(node, checked);
+							instance._updateCheckedNodes(node, checked, false);
 						}
 					},
 
@@ -236,7 +236,7 @@ AUI.add(
 						var node = event.node;
 
 						if (node.get('checked')) {
-							instance._updateCheckedNodes(node, true);
+							instance._updateCheckedNodes(node, true, false);
 						}
 
 						instance._restoreCheckedNode(node);
@@ -280,7 +280,7 @@ AUI.add(
 						node.get('children').forEach(A.bind(instance._restoreCheckedNode, instance));
 					},
 
-					_updateCheckedNodes: function(node, state) {
+					_updateCheckedNodes: function(node, state, force) {
 						var instance = this;
 
 						var plid = instance.get(STR_HOST).extractPlid(node);
@@ -292,6 +292,14 @@ AUI.add(
 						var checkedIndex = checkedNodes.indexOf(plid);
 						var localCheckedIndex = localCheckedNodes.indexOf(plid);
 						var localUncheckedIndex = localUncheckedNodes.indexOf(plid);
+
+						if (state === undefined) {
+							state = false;
+
+							if (checkedIndex > -1) {
+								state = true;
+							}
+						}
 
 						if (state) {
 							if (checkedIndex === -1) {
@@ -319,6 +327,10 @@ AUI.add(
 						node.set('checked', state);
 
 						var children = node.get('children');
+
+						if (force === false) {
+							state = undefined;
+						}
 
 						if (children.length) {
 							A.each(


### PR DESCRIPTION
/cc @blzaugg @daledotshan @zxdgoal

Hey @jonmak08,

This is an update for [LPS-67718](https://issues.liferay.com/browse/LPS-67718). Please let me know if you have any questions.

Thanks!

From Byran:

> Reviewed UI behavior and forwarded. No code review.
> 
> > This is a fix for [LPS-67718](https://issues.liferay.com/browse/LPS-67718)
> > 
> > The issue is that when we select a parent page, and deselect some its children pages, after click on "load more results"(IO request), the deselected nodes are selected automatically.
> > 
> > The reason is that when IO completes, we will call ``_updateCheckedNodes``, which will force all chidlren node to be the same state with their parent node.
> > 
> > To solve this issue, updateCheckedNodes requires to be able to resolve two basic scenarios:
> > 
> > 1. Explicit updateCheckedNodes. When click/unclick on a parent node, we expect all its children nodes to be selected/unselected automatically. In this case, we force all children node having consistent states with their parents.
> > 
> > 2. Implict updateCheckedNodes. When click on load more results or detect childrenNodeChanges, we expect the all local changed children nodes remaining their current status and new loaded children nodes respect their original states. In this case, we allow children nodes and their parents having different states.
> > 
> > Let know if you have any concerns about the fix.
> > 
> > /cc @daledotshan @jonmak08
> > 
> > Thanks
> > John.