### PR TITLE
LPS-68543 Session isn't auto extended when session.timeout.auto.extend is set to true

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-web/build.gradle
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/build.gradle
@@ -179,7 +179,8 @@ dependencies {
 
 	lodash group: "org.webjars.bower", name: "lodash", transitive: false, version: lodashVersion
 
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -328,10 +328,10 @@ AUI.add(
 									elapsed = timeOffset;
 								}
 
-								var extend = false;
+								var extend = instance.get('autoExtend');
 
-								var expirationMoment = elapsed == sessionLength;
-								var warningMoment = elapsed == warningTime;
+								var expirationMoment = false;
+								var warningMoment = false;
 
 								var hasExpired = elapsed >= sessionLength;
 								var hasWarned = elapsed >= warningTime;
@@ -339,35 +339,31 @@ AUI.add(
 								var updateSessionState = true;
 
 								if (hasWarned) {
-									if (warningMoment || expirationMoment) {
-										if (timestamp == 'expired') {
-											expirationMoment = true;
-											hasExpired = true;
-										}
-										else if (instance.get('autoExtend')) {
-											expirationMoment = false;
-											extend = true;
-											hasExpired = false;
-											hasWarned = false;
-											warningMoment = false;
-										}
-										else if (timeOffset < warningTime) {
-											hasWarned = false;
-											updateSessionState = false;
-										}
+									if (timestamp == 'expired') {
+										expirationMoment = true;
+										hasExpired = true;
 									}
 
 									if (updateSessionState) {
 										var sessionState = instance.get('sessionState');
 
 										if (hasExpired && sessionState != 'expired') {
-											instance.expire();
+											if (extend) {
+
+												hasExpired = false;
+												hasWarned = false;
+												expirationMoment = false;
+												warningMoment = false;
+
+												instance.extend();
+											} else {
+												instance.expire();
+												expirationMoment = true
+											}
 										}
 										else if (hasWarned && !hasExpired && sessionState != 'warned') {
 											instance.warn();
-										}
-										else if (extend) {
-											instance.extend();
+											warningMoment = true;
 										}
 									}
 								}

--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -313,6 +313,7 @@ AUI.add(
 						var registered = instance._registered;
 
 						var interval = 1000;
+						var sessionExtendOffset = 1000;
 
 						instance._intervalId = A.setInterval(
 							function() {
@@ -335,6 +336,11 @@ AUI.add(
 
 								var hasExpired = elapsed >= sessionLength;
 								var hasWarned = elapsed >= warningTime;
+
+								if (extend){
+									hasExpired = (elapsed + sessionExtendOffset >= sessionLength);
+									hasWarned = (elapsed + sessionExtendOffset >= warningTime);									
+								}
 
 								var updateSessionState = true;
 

--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -33,6 +33,9 @@ AUI.add(
 					redirectUrl: {
 						value: ''
 					},
+					sessionExtendOffset: {
+						value: 0
+					},
 					sessionLength: {
 						getter: '_getLengthInMillis',
 						value: 0
@@ -313,7 +316,7 @@ AUI.add(
 						var registered = instance._registered;
 
 						var interval = 1000;
-						var sessionExtendOffset = 1000;
+						var sessionExtendOffset = instance.get('sessionExtendOffset') * 1000;
 
 						instance._intervalId = A.setInterval(
 							function() {
@@ -337,9 +340,9 @@ AUI.add(
 								var hasExpired = elapsed >= sessionLength;
 								var hasWarned = elapsed >= warningTime;
 
-								if (extend){
+								if (extend) {
 									hasExpired = (elapsed + sessionExtendOffset >= sessionLength);
-									hasWarned = (elapsed + sessionExtendOffset >= warningTime);									
+									hasWarned = (elapsed + sessionExtendOffset >= warningTime);
 								}
 
 								var updateSessionState = true;

--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -370,7 +370,7 @@ AUI.add(
 												expirationMoment = true
 											}
 										}
-										else if (hasWarned && !hasExpired && sessionState != 'warned') {
+										else if (hasWarned && !hasExpired && !extend && sessionState != 'warned') {
 											instance.warn();
 											warningMoment = true;
 										}

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1376,6 +1376,8 @@ public class PropsValues {
 
 	public static final boolean SESSION_TIMEOUT_AUTO_EXTEND = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.SESSION_TIMEOUT_AUTO_EXTEND));
 
+	public static final int SESSION_TIMEOUT_AUTO_EXTEND_OFFSET = GetterUtil.getInteger(PropsUtil.get(PropsKeys.SESSION_TIMEOUT_AUTO_EXTEND_OFFSET));
+
 	public static final boolean SESSION_TIMEOUT_REDIRECT_ON_EXPIRE = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.SESSION_TIMEOUT_REDIRECT_ON_EXPIRE));
 
 	public static final int SESSION_TIMEOUT_WARNING = GetterUtil.getInteger(PropsUtil.get(PropsKeys.SESSION_TIMEOUT_WARNING));

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -2660,6 +2660,12 @@
     session.timeout.auto.extend=false
 
     #
+    # When session.timeout.auto.extend=true, set the number of seconds between
+    # the extend process is launched and the actual expiration of the session.
+    #
+    session.timeout.auto.extend.offset=1
+
+    #
     # Set this to true if the user is redirected to the default page when the
     # session expires.
     #

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1899,6 +1899,8 @@ public interface PropsKeys {
 
 	public static final String SESSION_TIMEOUT_AUTO_EXTEND = "session.timeout.auto.extend";
 
+	public static final String SESSION_TIMEOUT_AUTO_EXTEND_OFFSET = "session.timeout.auto.extend.offset";
+
 	public static final String SESSION_TIMEOUT_REDIRECT_ON_EXPIRE = "session.timeout.redirect.on.expire";
 
 	public static final String SESSION_TIMEOUT_WARNING = "session.timeout.warning";

--- a/portal-web/docroot/html/common/themes/session_timeout.jspf
+++ b/portal-web/docroot/html/common/themes/session_timeout.jspf
@@ -27,6 +27,7 @@
 					autoExtend: <%= !themeDisplay.isSignedIn() || PropsValues.SESSION_TIMEOUT_AUTO_EXTEND %>,
 					redirectOnExpire: <%= SSOUtil.isSessionRedirectOnExpire(themeDisplay.getCompanyId()) %>,
 					redirectUrl: '<%= HtmlUtil.escapeJS(SSOUtil.getSessionExpirationRedirectURL(themeDisplay.getCompanyId(), themeDisplay.getURLHome())) %>',
+					sessionExtendOffset: <%= PropsValues.SESSION_TIMEOUT_AUTO_EXTEND_OFFSET %>,
 					sessionLength: <%= PropsValues.SESSION_TIMEOUT %>,
 					warningLength: <%= PropsValues.SESSION_TIMEOUT_WARNING %>
 				}


### PR DESCRIPTION
Hi Jon,

In this PR, I've tried to sort out several issues when auto.extend=true:

**1.-** We are using 'expirationMoment' and 'warningMoment' variables as the key to trigger warn, extend and expire events, but after changes in [LPS-64627](https://issues.liferay.com/browse/LPS-64627), it is possible those variables were always false because we are not increasing sequentially 'elapsed' variable. You can check this including a log in session.js and checking the value of 'elapsed' variable. After a couple of minutes, you'll see some theorical values are skipped.

**2.-** Analyzing the LESA ticket [FCBARCELONAWEB-44](https://web.liferay.com/group/customer/support/-/support/ticket/FCBARCELONAWEB-44), we saw that in some cases (for example when the network connection between client and server is not good enough or if there is high load) when the extend event reachs the server, the session has already expired. So, we need an offset, in case auto.extend=true to avoid that behaviour, and the value of the offset could be different in every environment.

**3.-** Finally, if we define auto.extend=true, it does not make sense to show 'extend warning'.

Thanks for the review.

Regards,