### PR TITLE
[Technical Support] LPS-69112 Calendar portlet styling is broken when displayed in a layout column smaller than the full page

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
@@ -682,3 +682,162 @@
 		}
 	}
 }
+
+.col-md-4 {
+	.calendar-portlet-column-parent {
+		.calendar-list-item-arrow {
+			font-size: 1.75em;
+			top: 4px;
+
+			.icon-caret-down {
+				padding: 0 6px;
+			}
+		}
+
+		.calendar-portlet-column-grid, .calendar-portlet-column-options {
+			width: 100%;
+		}
+
+		.calendar-portlet-list-header {
+			.calendar-list-item-arrow {
+				top: 6px;
+			}
+		}
+
+		.scheduler-base-content .scheduler-base-hd .scheduler-base-views {
+			margin-top: 4px;
+		}
+
+		.scheduler-base-content .scheduler-base-view-date,
+		.scheduler-base-content .scheduler-base-controls,
+		.scheduler-base-content .scheduler-base-controls .btn-group,
+		.scheduler-base-content .scheduler-base-hd .scheduler-base-views {
+			text-align: center;
+			width: 100%;
+		}
+
+		.scheduler-base-controls {
+			.btn-group .calendar-add-event-btn {
+				margin-bottom: 5px;
+				width: 100%;
+			}
+		}
+
+		.scheduler-base-controls .btn-group .scheduler-base-today {
+			width: 50%;
+		}
+
+		.scheduler-base-hd .btn-group button {
+			width: 25%;
+		}
+
+		.scheduler-view-day-header-day-weekday {
+			font-size: 0;
+
+			&:first-letter {
+				font-size: 14px;
+			}
+		}
+
+		.scheduler-view-table-header-day div {
+			overflow: hidden
+		}
+
+		.simple-color-picker-item {
+			height: 18px;
+			width: 18px;
+		}
+	}
+}
+
+.col-md-6, .col-md-8 {
+	.calendar-portlet-column-parent {
+		.calendar-portlet-column-grid {
+			.scheduler-base-content .scheduler-base-hd .scheduler-base-controls {
+				width: 100%;
+
+				.btn-group:nth-child(1) {
+					margin-right: 3px;
+
+					.calendar-add-event-btn {
+						width: 100%;
+					}
+				}
+
+				.btn-group:nth-child(2) {
+					float: right;
+				}
+			}
+
+			.scheduler-base-content .scheduler-base-hd .scheduler-base-views {
+				width: 100%;
+
+				button {
+					width: 25%;
+				}
+			}
+		}
+	}
+}
+
+.col-md-6 {
+	.calendar-portlet-column-parent {
+		.calendar-portlet-column-grid {
+			width: 64%;
+
+			.scheduler-base-content .scheduler-base-hd .scheduler-base-controls {
+				.btn-group:nth-child(1) {
+					width: 49%;
+				}
+
+				.btn-group:nth-child(2) {
+					width: 49%;
+
+					button:nth-child(1), button:nth-child(3) {
+						padding-left: 10px;
+						padding-right: 10px;
+						width: 25%;
+					}
+
+					button:nth-child(2) {
+						width: 50%;
+					}
+				}
+			}
+		}
+
+		.calendar-portlet-column-options {
+			width: 36%;
+		}
+	}
+}
+
+.col-md-8 {
+	.calendar-portlet-column-parent {
+		.calendar-portlet-column-grid {
+			width: 70%;
+
+			.scheduler-base-content .scheduler-base-hd .scheduler-base-controls {
+				.btn-group:nth-child(1) {
+					width: 45%;
+				}
+
+				.btn-group:nth-child(2) {
+					width: 45%;
+
+					button:nth-child(1), button:nth-child(3) {
+						width: 30%;
+					}
+
+					button:nth-child(2) {
+						width: 40%;
+					}
+				}
+			}
+		}
+
+		.calendar-portlet-column-options {
+			width: 30%;
+		}
+	}
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
@@ -922,9 +922,7 @@
 				<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
 			</then>
 			<else>
-				<execute function="Click" locator1="Icon#INFO" />
-
-				<execute function="Click" locator1="Icon#HISTORY_VERTICAL_ELLIPSIS" />
+				<execute function="Click" locator1="Icon#HEADER_VERTICAL_ELLIPSIS" />
 			</else>
 		</if>
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/usecase/BlogsUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/usecase/BlogsUsecase.testcase
@@ -103,7 +103,7 @@
 			<var name="uploadFileName" value="Document_1.jpg" />
 		</execute>
 
-		<execute macro="PortletEntry#publish" />
+		<execute macro="PortletEntry#publishAndWait" />
 
 		<execute macro="Navigator#gotoPage">
 			<var name="pageName" value="${pageName}" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/usecase/DocumentsadministrationUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/usecase/DocumentsadministrationUsecase.testcase
@@ -803,12 +803,18 @@
 			<var name="roleDescription" value="This is the technical writer role" />
 			<var name="roleKey" value="Technical Writer" />
 			<var name="roleName" value="Writer" />
+			<var name="roleTitle" value="Technical Writer" />
 			<var name="roleType" value="Regular Role" />
+		</execute>
+
+		<execute macro="ProductMenu#gotoControlPanelUsers">
+			<var name="portlet" value="Roles" />
 		</execute>
 
 		<execute macro="Role#definePermissionsCP">
 			<var name="permissionDefinitionKeys" value="SITE_ADMIN_CONTENT_DOCUMENTS_AND_MEDIA_GENERAL_PERMISSIONS_VIEW_CHECKBOX,SITE_ADMIN_CONTENT_DOCUMENTS_AND_MEDIA_DOCUMENT_TYPE_DELETE_CHECKBOX,SITE_ADMIN_CONTENT_DOCUMENTS_AND_MEDIA_DOCUMENT_TYPE_UPDATE_CHECKBOX,SITE_ADMIN_CONTENT_DOCUMENTS_AND_MEDIA_DOCUMENT_TYPE_VIEW_CHECKBOX" />
 			<var name="roleTitle" value="Technical Writer" />
+			<var name="roleType" value="Regular Role" />
 		</execute>
 
 		<execute macro="ProductMenu#gotoControlPanelUsers">

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/usecase/DocumentsadministrationUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/usecase/DocumentsadministrationUsecase.testcase
@@ -770,6 +770,11 @@
 	</command>
 
 	<command name="UpdateDocumentTypeWithPermissions" priority="3">
+		<execute macro="TestCase#getSiteName">
+			<return from="siteName" name="siteName" />
+			<var name="siteName" value="${siteName}" />
+		</execute>
+
 		<execute macro="ProductMenu#gotoSitesContent">
 			<var name="portlet" value="Documents and Media" />
 		</execute>
@@ -881,7 +886,7 @@
 		</execute>
 
 		<execute macro="Site#assignUserSitesCP">
-			<var name="siteName" value="Liferay" />
+			<var name="siteName" value="${siteName}" />
 			<var name="userScreenName" value="usersn" />
 		</execute>
 
@@ -922,7 +927,7 @@
 		</execute>
 
 		<execute macro="Site#assignUserSitesCP">
-			<var name="siteName" value="Liferay" />
+			<var name="siteName" value="${siteName}" />
 			<var name="userScreenName" value="usersn2" />
 		</execute>
 


### PR DESCRIPTION
/cc @brandizzi

Hey @jonmak08,

This is an update for https://issues.liferay.com/browse/LPS-69112. I've added screenshots to the ticket for a visual example of what the portlet looked like in smaller layout columns before and after the fix.

Below I'm adding some line comments to specify which parts of the code fix which layout columns. If you'd like me to divide them up into separate commits, let me know and I can resend.

Please let me know if you have any questions.

Thanks!