### PR TITLE
[Technical Support] LPS-69462 master

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/form.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/form.js
@@ -14,7 +14,7 @@ AUI.add(
 		};
 
 		var number = function(val, node, ruleValue) {
-			var regex = /^[+\-]?(\d+)(\.\d+)?([eE][+-]?\d+)?$/;
+			var regex = /^[+\-]?(\d+)([.|,]\d+)*([eE][+-]?\d+)?$/;
 
 			return regex && regex.test(val);
 		};


### PR DESCRIPTION
/cc @peterborkuti @omarzzn3 

Hey @jonmak08, this is an update for https://issues.liferay.com/browse/LPS-69462.

From Peter:

> The previous number pattern rejects numbers like this:
> 123.456,78
> 
> The "." is the thousand separator in German and "," is the decimal separator.
> I know, that we have not dealt with thousand separators for any languages, however our customer is German so they stick to it. The decimal separator is necessary we also use "," in Hungary.
> What bothers me is that it is not truly language independent (there are more thousand separators, like " " in Hungary) and it allows forbidden constructions, like 123,456.789,90. But this fix is easy and solves the customer's issue.