### PR TITLE
LPS-31202 Allow <aui:input> to set default values for tags/categories

### DIFF
--- a/portal-web/docroot/html/taglib/aui/input/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/page.jsp
@@ -50,6 +50,7 @@
 			className="<%= model.getName() %>"
 			classPK="<%= _getClassPK(bean, classPK) %>"
 			contentCallback='<%= portletResponse.getNamespace() + "getSuggestionsContent" %>'
+			curCategoryIds="<%= (String) value %>"
 		/>
 	</c:when>
 	<c:when test='<%= (model != null) && type.equals("assetTags") %>'>
@@ -58,6 +59,7 @@
 			classPK="<%= _getClassPK(bean, classPK) %>"
 			contentCallback='<%= portletResponse.getNamespace() + "getSuggestionsContent" %>'
 			id="<%= namespace + id %>"
+			curTags="<%= (String) value %>"
 		/>
 	</c:when>
 	<c:when test="<%= (model != null) && Validator.isNull(type) %>">


### PR DESCRIPTION
@jonmak08,

This implements the contributed solution from <https://issues.liferay.com/browse/LPS-31202> .

When setting a default tag, any string may be used. However, when setting a default category, the id of an _existing_ category must be used in order for the default category to take effect.

 