### PR TITLE
LPS-31202 Allow <aui:input> to accept default tags/categories

### DIFF
--- a/portal-web/docroot/html/taglib/aui/input/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/page.jsp
@@ -64,6 +64,7 @@ boolean choiceField = checkboxField || radioField;
 			className="<%= model.getName() %>"
 			classPK="<%= _getClassPK(bean, classPK) %>"
 			contentCallback='<%= portletResponse.getNamespace() + "getSuggestionsContent" %>'
+			curCategoryIds="<%= (String) value %>"
 			ignoreRequestValue="<%= ignoreRequestValue %>"
 		/>
 	</c:when>
@@ -73,6 +74,7 @@ boolean choiceField = checkboxField || radioField;
 			className="<%= model.getName() %>"
 			classPK="<%= _getClassPK(bean, classPK) %>"
 			contentCallback='<%= portletResponse.getNamespace() + "getSuggestionsContent" %>'
+			curTags="<%= (String) value %>"
 			id="<%= namespace + id %>"
 			ignoreRequestValue="<%= ignoreRequestValue %>"
 		/>


### PR DESCRIPTION
@jonmak08 

Ticket: https://issues.liferay.com/browse/LPS-31202

After a some more searching, I found that the same functionality does currently exist in portal master / 7.0.x, so this issue only affects 6.2.x and below. 

Default categories are set in 7.0.x / master by passing the `categoryIds` attribute to the `<liferay-asset:asset-categories-selector>` taglib, and default tags are set via the `tagNames` attribute of the `<liferay-asset:asset-tags-selector>` taglib. 