### PR TITLE
LPS-72224 - Remove unnecessary markup causing text overflow

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
@@ -119,17 +119,11 @@ Hits hits = searchDisplayContext.getHits();
 			<liferay-ui:search-iterator displayStyle="descriptive" markupView="lexicon" type="more" />
 
 			<c:if test="<%= searchDisplayContext.isDisplayMainQuery() && (hits.getQuery() != null) %>">
-				<table class="full-query">
-					<tr>
-						<td valign="top">
-							<div class="container">
-								<code>
-									<%= HtmlUtil.escape(IndexSearcherHelperUtil.getQueryString(searchDisplayContext.getSearchContext(), hits.getQuery())) %>
-								</code>
-							</div>
-						</td>
-					</tr>
-				</table>
+				<div class="full-query">
+					<code>
+						<%= HtmlUtil.escape(IndexSearcherHelperUtil.getQueryString(searchDisplayContext.getSearchContext(), hits.getQuery())) %>
+					</code>
+				</div>
 			</c:if>
 		</liferay-ui:search-container>
 	</aui:col>


### PR DESCRIPTION
http://issues.liferay.com/browse/LPS-72224 <br><br>The div with class container has a fixed width which was causing the text to go off screen. I kept the containing div to make sure the query string was on its own line.