### PR TITLE
LPS-71915-control-menu

### DIFF
--- a/modules/apps/web-experience/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/web-experience/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
@@ -25,7 +25,7 @@
 			white-space: nowrap;
 			word-break: normal;
 			word-wrap: normal;
-			width: 250px;
+			max-width: 250px;
 		}
 
 		.sidenav-close {

--- a/modules/apps/web-experience/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/web-experience/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
@@ -14,6 +14,20 @@
 			padding-top: 16px;
 		}
 
+		.company-details {
+			display: flex;
+		}
+
+		.company-name {
+			display: block;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			word-break: normal;
+			word-wrap: normal;
+			width: 250px;
+		}
+
 		.sidenav-close {
 			float: right;
 			margin-right: -2px;


### PR DESCRIPTION
Added classes to style company-detail and company-name within the side bar header to fix company name from overflowing into menu.

This fix is similar to a truncate styling used further down in the menu.