### PR TITLE
LPS-74319 MDR don't update in site page configuration if more than one change is made

### DIFF
--- a/modules/apps/foundation/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/layout/mobile_device_rules.jsp
+++ b/modules/apps/foundation/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/layout/mobile_device_rules.jsp
@@ -55,7 +55,7 @@ int mdrRuleGroupInstancesCount = MDRRuleGroupInstanceServiceUtil.getRuleGroupIns
 	</p>
 </div>
 
-<div class="<%= (mdrRuleGroupInstancesCount > 0) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />uniqueRuleGroupInstancesContainer">
+<div class="<%= (mdrRuleGroupInstancesCount > 0) ? "unique-rule-group-instances-container" : "hide" %>" id="<portlet:namespace />uniqueRuleGroupInstancesContainer">
 	<p class="text-muted">
 		<liferay-ui:message key="device-family" />
 	</p>

--- a/modules/apps/foundation/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/layout/mobile_device_rules_rule_group_instances.jsp
+++ b/modules/apps/foundation/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/layout/mobile_device_rules_rule_group_instances.jsp
@@ -60,7 +60,7 @@ PortletURL portletURL = (PortletURL)request.getAttribute("mobile_device_rules_he
 
 <c:if test="<%= themeDisplay.isStateExclusive() %>">
 	<aui:script sandbox="<%= true %>">
-		$('#<portlet:namespace />uniqueRuleGroupInstancesContainer').on(
+		$('.unique-rule-group-instances-container').on(
 			'click',
 			'.mobile-device-rule a',
 			function(event) {

--- a/modules/apps/foundation/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/layout/mobile_device_rules_toolbar.jspf
+++ b/modules/apps/foundation/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/layout/mobile_device_rules_toolbar.jspf
@@ -46,7 +46,7 @@
 			'<%= viewRuleGroupInstancesURL.toString() %>',
 			{
 				success: function(responseData) {
-					$('#<portlet:namespace />uniqueRuleGroupInstancesContainer').html(responseData);
+					$('.unique-rule-group-instances-container').html(responseData);
 				}
 			}
 		);

--- a/modules/apps/foundation/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/layout_set/mobile_device_rules.jsp
+++ b/modules/apps/foundation/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/layout_set/mobile_device_rules.jsp
@@ -35,7 +35,7 @@ long classPK = selLayoutSet.getLayoutSetId();
 
 <%@ include file="/layout/mobile_device_rules_header.jspf" %>
 
-<div id="<portlet:namespace />uniqueRuleGroupInstancesContainer">
+<div class="unique-rule-group-instances-container" id="<portlet:namespace />uniqueRuleGroupInstancesContainer">
 	<liferay-util:include page="/layout/mobile_device_rules_rule_group_instances.jsp" servletContext="<%= application %>">
 		<liferay-util:param name="groupId" value="<%= String.valueOf(groupId) %>" />
 		<liferay-util:param name="className" value="<%= className %>" />


### PR DESCRIPTION
Hey @jonmak08,

Here's an update for https://issues.liferay.com/browse/LPS-74319. 

When the MDR jsp is rendered from the FormNavigator tag in the "Advanced" tab of Configure Page, it uses the layouts admin namespace. However once user interaction occurs via button click (either select or delete of a mobile device rule), the response uses the MDR namespace. The fix should be to always use the MDR namespace.

After asking several backend developers, I wasn't able to figure out how to do that quite yet. Since you mentioned that this ticket is needed for a release and ideally be completed by today, I'm submitting a workaround. Please let me know if you have better ideas on how to address this issue. 

Thanks,
Rebecca

