### PR TITLE
[TECHNICAL-SUPPORT] LPS-75363

### DIFF
--- a/modules/apps/foundation/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/email_notification_settings/page.jsp
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/email_notification_settings/page.jsp
@@ -36,42 +36,26 @@ boolean showSubject = GetterUtil.getBoolean(request.getAttribute("liferay-fronte
 	</c:if>
 
 	<c:if test="<%= showSubject %>">
-		<c:choose>
-			<c:when test="<%= Validator.isNotNull(emailSubject) && Validator.isXml(emailSubject) %>">
-				<aui:field-wrapper label="subject">
-					<liferay-ui:input-localized
-						fieldPrefix="<%= fieldPrefix %>"
-						fieldPrefixSeparator="<%= fieldPrefixSeparator %>"
-						name='<%= emailParam + "Subject" %>'
-						xml="<%= emailSubject %>"
-					/>
-				</aui:field-wrapper>
-			</c:when>
-			<c:otherwise>
-				<aui:input cssClass="lfr-input-text-container" label="subject" name='<%= fieldPrefix + fieldPrefixSeparator + emailParam + "Subject" + fieldPrefixSeparator %>' value="<%= emailSubject %>" />
-			</c:otherwise>
-		</c:choose>
+		<aui:field-wrapper label="subject">
+			<liferay-ui:input-localized
+				fieldPrefix="<%= fieldPrefix %>"
+				fieldPrefixSeparator="<%= fieldPrefixSeparator %>"
+				name='<%= emailParam + "Subject" %>'
+				xml="<%= emailSubject %>"
+			/>
+		</aui:field-wrapper>
 	</c:if>
 
 	<aui:field-wrapper helpMessage="<%= helpMessage %>" label="<%= bodyLabel %>">
-		<c:choose>
-			<c:when test="<%= Validator.isNotNull(emailBody) && Validator.isXml(emailBody) %>">
-				<liferay-ui:input-localized
-					editorName='<%= PropsUtil.get("editor.wysiwyg.portal-web.docroot.html.taglib.ui.email_notification_settings.jsp") %>'
-					fieldPrefix="<%= fieldPrefix %>"
-					fieldPrefixSeparator="<%= fieldPrefixSeparator %>"
-					name='<%= emailParam + "Body" %>'
-					toolbarSet="email"
-					type="editor"
-					xml="<%= emailBody %>"
-				/>
-			</c:when>
-			<c:otherwise>
-				<liferay-ui:input-editor contents="<%= emailBody %>" editorName='<%= PropsUtil.get("editor.wysiwyg.portal-web.docroot.html.taglib.ui.email_notification_settings.jsp") %>' name="<%= emailParam %>" />
-
-				<aui:input name='<%= fieldPrefix + fieldPrefixSeparator + emailParam + "Body" + fieldPrefixSeparator %>' type="hidden" />
-			</c:otherwise>
-		</c:choose>
+		<liferay-ui:input-localized
+			editorName='<%= PropsUtil.get("editor.wysiwyg.portal-web.docroot.html.taglib.ui.email_notification_settings.jsp") %>'
+			fieldPrefix="<%= fieldPrefix %>"
+			fieldPrefixSeparator="<%= fieldPrefixSeparator %>"
+			name='<%= emailParam + "Body" %>'
+			toolbarSet="email"
+			type="editor"
+			xml="<%= emailBody %>"
+		/>
 	</aui:field-wrapper>
 </aui:fieldset>
 


### PR DESCRIPTION
Hey @jonmak08,

The issue here is that the input created when the subject or body is null or invalid XML does not have a sense of localization. Due to this, the input's name looks like:

```
_com_liferay_portal_settings_web_portlet_PortalSettingsPortlet_settings--adminEmailPasswordSentBody--
```

When it should be:

```
_com_liferay_portal_settings_web_portlet_PortalSettingsPortlet_settings--adminEmailPasswordSentBody_en_US--
```

Since the locale is missing, saving and fetching the record does not function properly.

Please let me know if you have any questions.