### PR TITLE
LPS-78835 Master set left and display properties for basic-search-slider class on mobile screen

### DIFF
--- a/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_input_search.scss
+++ b/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_input_search.scss
@@ -3,3 +3,12 @@
 		vertical-align: top;
 	}
 }
+
+@media (max-width: 768px) {
+	.input-group-input {
+		.basic-search-slider {
+			display: flex;
+			left: 0;
+		}
+	}
+}


### PR DESCRIPTION
Note: I was able to reproduce the bug by using the Chrome mobile view using the dev tools.  Simulation closes once the Product Menu is opened.