### PR TITLE
LPS-78777 Add portlet dropzone highlight when portlet over draggable

### DIFF
--- a/modules/apps/foundation/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_drag_drop.scss
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_drag_drop.scss
@@ -75,3 +75,9 @@
 .yui3-dd-proxy {
 	z-index: 1110 !important;
 }
+
+.yui3-dd-drop-over {
+	.portlet-dropzone {
+		box-shadow: inset 0px 4px 0px 0px #0B5FFF;
+	}
+}


### PR DESCRIPTION
area

https://issues.liferay.com/browse/LPS-78777

Not sure if we'd want to highlight the dropzone or if box-shadow is the proper property to use. (border-top? outline?).