### PR TITLE
LPS-79067 Removed close button from input-search taglib

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_search/lexicon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_search/lexicon/page.jsp
@@ -38,9 +38,7 @@ String value = ParamUtil.getString(request, name);
 	<div class="input-group-input">
 		<label class="hide-accessible" for="<%= namespace + id %>"><%= title %></label>
 
-		<div class="basic-search-slider">
-			<button class="basic-search-close btn btn-default" type="button"><aui:icon image="times" markupView="lexicon" /><span class="sr-only"><%= buttonLabel %></span></button>
-
+		<div class="basic-search-slider">			
 			<input class="form-control search-query" data-qa-id="searchInput" id="<%= namespace + id %>" name="<%= namespace + name %>" placeholder="<%= placeholder %>" title="<%= title %>" type="text" value="<%= HtmlUtil.escapeAttribute(value) %>" />
 		</div>
 	</div>


### PR DESCRIPTION
**Rationale to remove close button:**  input search form used to be in navbar (view.jsp in journal-web) as a slide toggle and now it is in management bar (toolbar.jsp in journal-web).  There is no need to slide toggle the search box any more since there is space for it.  So therefore I removed the close button.

I thought about putting it back into navbar like it was in 7.0.x to keep the fancy toggle, but now master is using clay:navigation-bar tag to render navbar.