### PR TITLE
LPS-83108  Removed padding

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
@@ -114,6 +114,10 @@
 	}
 
 	.sidenav-right {
+		.sidenav-content {
+			padding-right: 0 !important;
+		}
+
 		> .btn-group {
 			margin: 20px 0;
 		}


### PR DESCRIPTION
The shifting of the content was being caused by the padding, which is an inline style. Removing the padding fixed the issue.