### PR TITLE
LPS-75363 Setting an invalid email notification template results in the inability to alter it via the UI

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/email_notification_settings/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/email_notification_settings/page.jsp
@@ -67,13 +67,29 @@ boolean showSubject = GetterUtil.getBoolean(request.getAttribute("liferay-fronte
 				/>
 			</c:when>
 			<c:otherwise>
+
+				<%
+				String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_email_notification_settings") + StringPool.UNDERLINE;
+				%>
+
 				<liferay-ui:input-editor
 					contents="<%= emailBody %>"
 					editorName='<%= PropsUtil.get("editor.wysiwyg.portal-web.docroot.html.taglib.ui.email_notification_settings.jsp") %>'
-					name="<%= emailParam %>"
+					name='<%= emailParam + "BodyEditor" %>'
+					onChangeMethod='<%= randomNamespace + "OnChangeEditor" %>'
 				/>
 
 				<aui:input name='<%= fieldPrefix + fieldPrefixSeparator + emailParam + "Body" + fieldPrefixSeparator %>' type="hidden" />
+
+				<aui:script>
+					function <portlet:namespace /><%= randomNamespace %>OnChangeEditor(html) {
+						var input = document.getElementById('<portlet:namespace /><%= HtmlUtil.escapeJS(emailParam + "Body") %>')
+
+						if (input) {
+							input.setAttribute('value', html);
+						}
+					}
+				</aui:script>
 			</c:otherwise>
 		</c:choose>
 	</aui:field-wrapper>


### PR DESCRIPTION
This is an update for [LPS-75363](https://issues.liferay.com/browse/LPS-75363).<br><br>Hey Jon, my main question with this solution is: can I do even less than this?  I feel like I have seen situations where there is no javascript involved, but it may have just been obfuscated.<br><br>/cc @pei-jung @stsquared99 @jonathanmccann