### PR TITLE
LPS-84477 Add CSS to make the drag handle for image resizing larger f…

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_editor_ckeditor.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_editor_ckeditor.scss
@@ -39,3 +39,13 @@
 		height: 15px;
 	}
 }
+
+span .cke_image_resizer {
+	background-clip: content-box;
+	bottom: -15px;
+	height: 40px;
+	outline-color: transparent;
+	padding: 20px 10px 10px 20px;
+	right: -15px;
+	width: 40px;
+}


### PR DESCRIPTION
…or AlloyEditor on IE11 where it defaults to using the CKEditor behavior

Resending from https://github.com/jonmak08/liferay-portal/pull/1956

Changed location of fix into the styled theme's CKEditor CSS file which should work for admin theme and any theme built on top of styled. Please let me know what you think.