### PR TITLE
LPS-85564 Create scrollTo method for ios iPhone and fix message board…

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -879,6 +879,16 @@
 			);
 		},
 
+		scrollTo: function(el) {
+			if (AUI().UA.ios) {
+				var element = document.getElementById(el);
+
+				if (element && element.nodeType) {
+					element.scrollIntoView();
+				}
+			}
+		},
+
 		selectEntityHandler: function(container, selectEventName, disableButton) {
 			container = $(container);
 

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
@@ -76,6 +76,8 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 		window[editorName].setHTML(quote);
 		window[editorName].focus();
 
+		Liferay.Util.scrollTo('<portlet:namespace />addReplyToMessage' + messageId);
+
 		Liferay.Util.toggleDisabled('#<portlet:namespace />replyMessageButton' + messageId, true);
 	}
 


### PR DESCRIPTION
… scroll

https://issues.liferay.com/browse/LPS-85564

On iPhones, the view will not scroll to the editor when selecting reply in Message Boards. This is due to the fact iOS does not do autofocus unlike in Android or Desktop. 

A solution to this is to create a method that will scroll the screen to the desired location when it detects an iOS device. This method is not needed for Android or Desktop since autofocus functions correctly. With this method, we are keeping the native behavior of iOS by not focusing the editor but we are making it user friendly by displaying the editor.
If there are any comments or questions please let me know.

Thank you!