### PR TITLE
[TECHNICAL SUPPORT] LPS-87117 Site roles are incorrectly assigned when they are selected from different pages

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
@@ -194,7 +194,11 @@ AUI.add(
 							}
 						).filter(
 							function(item) {
-								const itemActions = item.getData('actions');
+								var itemActions;
+
+								if (item) {
+									itemActions = item.getData('actions');
+								}
 
 								return itemActions !== undefined && itemActions !== STR_ACTIONS_WILDCARD;
 


### PR DESCRIPTION
Hello @jonmak08 ,
cc @antonio-ortega

Issue: [LPS-87117](https://issues.liferay.com/browse/LPS-87117)
When selecting another role from the second page there is a js error:
`search_container_select.js?browserId=other&minifierType=&languageId=en_US&b=7101&t=1541500982239:197 Uncaught TypeError: Cannot read property 'getData' of null at search_container_select.js?browserId=other&minifierType=&languageId=en_US&b=7101&t=1541500982239:197 at Array.filter (<anonymous>) at component._getActions (search_container_select.js?browserId=other&minifierType=&languageId=en_US&b=7101&t=1541500982239:195) at component._notifyRowToggle (search_container_select.js?browserId=other&minifierType=&languageId=en_US&b=7101&t=1541500982239:254) at component.toggleRow (search_container_select.js?browserId=other&minifierType=&languageId=en_US&b=7101&t=1541500982239:136) at component._onClickRowSelector (search_container_select.js?browserId=other&minifierType=&languageId=en_US&b=7101&t=1541500982239:271) at component.<anonymous> (oop.js:403) at Y.Subscriber.delegate.notifySub [as _notify] (event-delegate.js:173) at Y.Subscriber.notify (event-custom-base.js:1335) at Y.CustomEvent._notify (event-custom-base.js:998)
`
I introduced a null check on 'item' to solve the issue.
Please review it,