### PR TITLE
LPS-89592 use table-cell instead of table for IE11

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/css/main.scss
@@ -336,7 +336,7 @@
 
 	.task-action-button {
 		bottom: 0;
-		display: table;
+		display: table-cell;
 		margin: 0;
 		padding: 1.5rem;
 		position: absolute;


### PR DESCRIPTION
Resent from https://github.com/gregory-bretall/liferay-portal/pull/147

https://issues.liferay.com/browse/LPS-89592

Please note Spencer's comment in regards to this https://github.com/gregory-bretall/liferay-portal/pull/147#issue-247788224

I wasn't able to find any issue with this fix in Firefox, Edge, or Chrome though so it seems ok to me. Please let me know if you have any feedback.

@SpencerWoo