### PR TITLE
LPS-88245

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_forms.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_forms.scss
@@ -1,6 +1,6 @@
 @if $compat-forms {
 	label {
-		max-width: 100%;
+		max-width: 96%;
 	}
 
 	// Indent the labels to position radios/checkboxes as hanging controls.


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88245

From @ajsampang67:
**Explanation:**
Long field labels were overlapping the repeatable field button. Shortened the width in order to avoid overlap. 

Passing SF test: https://github.com/ChrisKian/liferay-portal/pull/98#issuecomment-463413681
Passinf Relevant tests: https://github.com/ChrisKian/liferay-portal/pull/98#issuecomment-463438475