### PR TITLE
[TS] LPS-88234 Wiki attachment image with an ampersand in the file name does not appear in the editor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -351,7 +351,7 @@
 					try {
 						var itemValue = JSON.parse(selectedItem.value);
 
-						itemSrc = editor.config.attachmentURLPrefix ? editor.config.attachmentURLPrefix + itemValue.title : itemValue.url;
+						itemSrc = editor.config.attachmentURLPrefix ? editor.config.attachmentURLPrefix + encodeURIComponent(itemValue.title) : itemValue.url;
 					}
 					catch (e) {
 					}


### PR DESCRIPTION
Hi @jonmak08 ,

could you please review my changes and push it forward?

Thanks, Roland

https://issues.liferay.com/browse/LPS-88234
