### PR TITLE
LPS-91528

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
@@ -59,7 +59,6 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			jsonObject, inputEditorTaglibAttributes, themeDisplay,
 			requestBackedPortletURLFactory);
 
-		jsonObject.put("autoParagraph", Boolean.FALSE);
 		jsonObject.put("autoSaveTimeout", 3000);
 
 		ColorScheme colorScheme = themeDisplay.getColorScheme();


### PR DESCRIPTION
From @nellyliupeng 

> https://issues.liferay.com/browse/LPS-91528
> 
> Issue:
> Portlets that can use CKEditor are affected with additional space "\n" added when user adds html tags within a non-paragraph content. Space is added as it goes thru antisamy.
> ie. abc ---> ab c
> AlloyEditor does not face same issue as user's input is automatically enclosed in <p> tags. (However, notice that if you deliberately remove the <p> tags in the Code View then the issue will be reproduced).
> 
> Solution:
> Have CKEditor enclose content in paragraph (same behavior as current AlloyEditor).
> Testings were done with ckeditor-dev and liferay-ckeditor by itself and they do not reproduce issue as they autoparagraph content.
> 
> The CKEditor doc also includes this note about config.autoParagraph (default value is true):
> 
> Note: Changing the default value might introduce unpredictable usability issues.

CC @wanderlast 