### PR TITLE
LPS-88863 lexicon-icon-times X is not aligned consistently before and after submitting selection

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -106,7 +106,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 			modelVar="role"
 		>
 			<liferay-ui:search-container-column-text
-				cssClass="table-cell-content"
+				cssClass="table-cell-expand"
 				name="title"
 			>
 				<liferay-ui:icon
@@ -767,7 +767,13 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 						document.<portlet:namespace />fm.<portlet:namespace />deleteRoleIds.value = <portlet:namespace />deleteRoleIds.join(',');
 					}
 
-					searchContainer.addRow(rowColumns, roleId);
+					var searchRow = searchContainer.addRow(rowColumns, roleId);
+
+					var searchRole = searchRow.one('td');
+
+						if (searchRole) {
+							searchRole.addClass('table-cell-expand');
+						}
 
 					searchContainer.updateDataStore();
 				},


### PR DESCRIPTION
Fixed the issue with the lexicon-icon-times icon not being aligned before and after adding an item associated with the icon.

Updated the code with a conditional to check if the DOM node exists.