### PR TITLE
LPS-91383 Clay Custom Checkbox/Radio focus fix from ClayCSS 2.10.0

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_forms.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_forms.scss
@@ -273,3 +273,13 @@
 		}
 	}
 }
+
+// LPS-91383, LPS-89861
+
+.custom-control-input {
+	z-index: 1;
+}
+
+.form-check-card .custom-control-input {
+	z-index: 2;
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-91383

@jonmak08 this is a backport from Clay CSS 2.10.0. We couldn't up the version because font sizes for the `h1` - `h6` tags were made larger by the Lexicon Team. I felt like it was too big of a breaking change for 7.1.x.