### PR TITLE
LPS 81939 Vocabulary - Associated Asset Type (-) button works incorrectly

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
@@ -98,8 +98,9 @@ AUI.add(
 						var deleteRow = visibleRows > 1;
 
 						if (visibleRows == 1) {
-							instance.addRow(node);
-
+							deleteRow = false;
+						}
+						else if (visibleRows > 1) {
 							deleteRow = true;
 						}
 


### PR DESCRIPTION
Hey Jon. I fixed the issue with raising the number of deletions. I was able to disable the button, but ran into an issue where the minus button (<span>) was still firing the 'click' event. I spoke with Byran and we came to conclusion that we would open another ticket addressing the issue so that we can close this one (LPS-81939) out. The issue seems to be that the code for the 'click' event needs to be revamped. Here is a link to the created issue. https://issues.liferay.com/browse/LPS-92681.

Let me know if you have any questions or comments. Thanks!