### PR TITLE
LPS-91919 Change regex so as to capture just the final file extension…

### DIFF
--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
@@ -301,7 +301,7 @@ class ImageEditor extends PortletBase {
 	 */
 	setterSaveMimeTypeFn_(saveMimeType) {
 		if (!saveMimeType) {
-			const imageExtensionRegex = /(?:.*:\/\/)?(?:[^\/])*[^.]*.([^?\/$]*)/;
+			const imageExtensionRegex = /\.(\w+)\/[^?\/]+/;
 			const imageExtension = this.image.match(imageExtensionRegex)[1];
 
 			saveMimeType = `image/${imageExtension}`;


### PR DESCRIPTION
…, making mime types be more accurate for files with multiple dots

Sent directly to you since @blzaugg is going to be on PTO for next week and can't get to this during this week.

Let me know if you think there's a better way to get the mime type here from the image URL, I tried using the JS file object but IE11 and Edge don't support it so it was a bit of a dead end.

https://issues.liferay.com/browse/LPS-91919