### PR TITLE
[TS] LPS-93474

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -305,6 +305,9 @@ name = HtmlUtil.escapeJS(name);
 			if (win.instanceReady) {
 				setHTML(value);
 			}
+			else {
+				instancePendingData = value;
+			}
 		}
 	};
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-93474

From @nellyliupeng:

> This is an issue with how Liferay uses ckeditor.
> 
> Issue:
> When window is resized, the contents within the CKEditor disappear.
> 
> Fix:
> After some testing to narrow down origin of root cause, the behavior above was first introduced in LPS-79464 (brianchandotcom#59145), where new variables such as instanceDataReady, instancePendingData, 'dataReady', and 'setData' were introduced. This led me to think that a logic fix was needed to be added.
> 
> I attempted to take into account the scenario where win.instanceReady is false to store the ckeditor content into instancePendingData
> 
> if (win.instanceReady) {
>      setHTML(value);
> }
> (seems like when the window is resized win.instanceReady=false, which then will never call setHtml()).
> 
> Once 'dataReady',
> 
> if (instancePendingData) {
> 	var pendingData = instancePendingData;
>         instancePendingData = null;
>         ckEditor.setData(pendingData);
> }
> is called, and sets the ckeditor content data back.
> 
> Thank you, your time to take a look at logic of fix will be very appreciated!

From @wanderlast:

> I've looked a bit further into this and there's a bit of further context. It looks like there was similar logic previously in liferay@80b9c8b#diff-da25dc049971ff4bf74778ef84eac3c0R269 but that it was removed due to an incorrect variable (contents) being used in bcf5579. The fix seems logical to me based off these changes.

SF test passed: https://github.com/wanderlast/liferay-portal/pull/27#issuecomment-481372756
Test failures don't appear relevant in relevant test: https://github.com/wanderlast/liferay-portal/pull/27#issuecomment-481405292