### PR TITLE
LPS-95558 When scrolling in permissions popup, search container header should remain fixed to top of page.

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_search_container.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_search_container.scss
@@ -116,3 +116,8 @@
 		color: #009AE5;
 	}
 }
+
+.lfr-search-iterator-fixed-header {
+	position: absolute;
+	z-index: 100;
+}

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_search_container.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_search_container.scss
@@ -119,5 +119,10 @@
 
 .lfr-search-iterator-fixed-header {
 	position: absolute;
-	z-index: 100;
+	width: 100%;
+	z-index: $zindex-sticky;
+}
+
+.lfr-search-iterator-fixed-header-table {
+	position: relative;
 }

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -162,6 +162,7 @@ if (Validator.isNotNull(portletConfigurationPermissionsDisplayContext.getModelRe
 				</liferay-ui:search-container-row>
 
 				<liferay-ui:search-iterator
+					fixedHeader="true"
 					markupView="lexicon"
 				/>
 			</liferay-ui:search-container>

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -162,7 +162,7 @@ if (Validator.isNotNull(portletConfigurationPermissionsDisplayContext.getModelRe
 				</liferay-ui:search-container-row>
 
 				<liferay-ui:search-iterator
-					fixedHeader="true"
+					fixedHeader="<%= true %>"
 					markupView="lexicon"
 				/>
 			</liferay-ui:search-container>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
@@ -24,6 +24,7 @@ SearchContainer searchContainer = (SearchContainer)request.getAttribute("liferay
 
 boolean compactEmptyResultsMessage = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:search:compactEmptyResultsMessage"));
 String displayStyle = GetterUtil.getString((String)request.getAttribute("liferay-ui:search-iterator:displayStyle"), SearchIteratorTag.DEFAULT_DISPLAY_STYLE);
+boolean fixedHeader = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:search-iterator:fixedHeader"));
 String markupView = (String)request.getAttribute("liferay-ui:search-iterator:markupView");
 boolean paginate = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:search-iterator:paginate"));
 ResultRowSplitter resultRowSplitter = (ResultRowSplitter)request.getAttribute("liferay-ui:search-iterator:resultRowSplitter");

--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/bottom.jspf
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/bottom.jspf
@@ -92,6 +92,33 @@
 			}
 		).render();
 
+		<c:if test="<%= fixedHeader && displayStyle.equals(SearchIteratorTag.DEFAULT_DISPLAY_STYLE) %>">
+			var fixedHeader = document.getElementById('<%= namespace + id %>fixedHeader');
+			var scrollingContainer = window !== Liferay.Util.getOpener() ? window : searchContainer.get('contentBox').ancestor('#main-content')._node;
+			var tHeadBoundingClientRectangle = fixedHeader.previousElementSibling.getBoundingClientRect();
+
+			var fixedHeaderScrollEvent = function(event) {
+				console.log(scrollingContainer);
+				fixedHeader.style.transform = 'translateY(' + Math.ceil(scrollingContainer.scrollTop - tHeadBoundingClientRectangle.height) + 'px)';
+
+				if (fixedHeader.classList.contains('hide') && (scrollingContainer.scrollTop >= tHeadBoundingClientRectangle.height)) {
+					fixedHeader.classList.remove('hide');
+				}
+				else if (scrollingContainer.scrollTop < tHeadBoundingClientRectangle.height) {
+					fixedHeader.classList.add('hide');
+				}
+			};
+
+			scrollingContainer.addEventListener('scroll', fixedHeaderScrollEvent);
+
+			Liferay.on(
+				'destroyPortlet',
+				function() {
+					scrollingContainer.removeEventListener('scroll', fixedHeaderScrollEvent);
+				}
+			);
+		</c:if>
+
 		searchContainer.updateDataStore(<%= primaryKeysJSONArray.toString() %>);
 
 		var destroySearchContainer = function(event) {

--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/bottom.jspf
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/bottom.jspf
@@ -93,19 +93,19 @@
 		).render();
 
 		<c:if test="<%= fixedHeader && displayStyle.equals(SearchIteratorTag.DEFAULT_DISPLAY_STYLE) %>">
-			var fixedHeader = document.getElementById('<%= namespace + id %>fixedHeader');
-			var scrollingContainer = window !== Liferay.Util.getOpener() ? window : searchContainer.get('contentBox').ancestor('#main-content')._node;
-			var tHeadBoundingClientRectangle = fixedHeader.previousElementSibling.getBoundingClientRect();
+			var fixedHeaderElement = document.getElementById('<%= namespace + id %>fixedHeader');
+			var scrollingContainer = window === Liferay.Util.getOpener() ? window : searchContainer.get('contentBox').ancestor('#main-content')._node;
+			var tableElement = fixedHeaderElement.parentElement;
+			var theadBoundingClientRectangle = fixedHeaderElement.previousElementSibling.getBoundingClientRect();
 
 			var fixedHeaderScrollEvent = function(event) {
-				console.log(scrollingContainer);
-				fixedHeader.style.transform = 'translateY(' + Math.ceil(scrollingContainer.scrollTop - tHeadBoundingClientRectangle.height) + 'px)';
+				fixedHeaderElement.style.transform = 'translateY(' + Math.ceil(scrollingContainer.scrollTop - tableElement.offsetTop - theadBoundingClientRectangle.height) + 'px)';
 
-				if (fixedHeader.classList.contains('hide') && (scrollingContainer.scrollTop >= tHeadBoundingClientRectangle.height)) {
-					fixedHeader.classList.remove('hide');
+				if (fixedHeaderElement.classList.contains('hide') && (scrollingContainer.scrollTop >= theadBoundingClientRectangle.bottom)) {
+					fixedHeaderElement.classList.remove('hide');
 				}
-				else if (scrollingContainer.scrollTop < tHeadBoundingClientRectangle.height) {
-					fixedHeader.classList.add('hide');
+				else if (scrollingContainer.scrollTop < theadBoundingClientRectangle.bottom) {
+					fixedHeaderElement.classList.add('hide');
 				}
 			};
 

--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/bottom.jspf
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/bottom.jspf
@@ -95,6 +95,7 @@
 		<c:if test="<%= fixedHeader && displayStyle.equals(SearchIteratorTag.DEFAULT_DISPLAY_STYLE) %>">
 			var fixedHeaderElement = document.getElementById('<%= namespace + id %>fixedHeader');
 			var scrollingContainer = window === Liferay.Util.getOpener() ? window : searchContainer.get('contentBox').ancestor('#main-content')._node;
+
 			var tableElement = fixedHeaderElement.parentElement;
 			var theadBoundingClientRectangle = fixedHeaderElement.previousElementSibling.getBoundingClientRect();
 

--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
@@ -174,7 +174,7 @@ if (fixedHeader) {
 			</thead>
 
 			<c:if test="<%= fixedHeader %>">
-				<thead class="lfr-search-iterator-fixed-header hide" id="<%= namespace + id %>fixedHeader">
+				<thead class="hide lfr-search-iterator-fixed-header" id="<%= namespace + id %>fixedHeader">
 					<%= theadContent %>
 				</thead>
 			</c:if>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
@@ -39,6 +39,10 @@ if (!resultRowSplitterEntries.isEmpty()) {
 
 	firstResultRows = firstResultRowSplitterEntry.getResultRows();
 }
+
+if (fixedHeader) {
+	searchResultCssClass += " lfr-search-iterator-fixed-header-table";
+}
 %>
 
 <div class="table-responsive">
@@ -49,7 +53,7 @@ if (!resultRowSplitterEntries.isEmpty()) {
 
 		<c:if test="<%= ListUtil.isNotNull(headerNames) %>">
 			<liferay-util:buffer
-				var="tableHeaderContent"
+				var="theadContent"
 			>
 				<tr>
 
@@ -166,13 +170,12 @@ if (!resultRowSplitterEntries.isEmpty()) {
 			</liferay-util:buffer>
 
 			<thead>
-				<%= tableHeader %>
+				<%= theadContent %>
 			</thead>
-
 
 			<c:if test="<%= fixedHeader %>">
 				<thead class="lfr-search-iterator-fixed-header hide" id="<%= namespace + id %>fixedHeader">
-					<%= tableHeader %>
+					<%= theadContent %>
 				</thead>
 			</c:if>
 		</c:if>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
@@ -48,7 +48,9 @@ if (!resultRowSplitterEntries.isEmpty()) {
 		</c:if>
 
 		<c:if test="<%= ListUtil.isNotNull(headerNames) %>">
-			<thead>
+			<liferay-util:buffer
+				var="tableHeaderContent"
+			>
 				<tr>
 
 					<%
@@ -161,7 +163,18 @@ if (!resultRowSplitterEntries.isEmpty()) {
 					%>
 
 				</tr>
+			</liferay-util:buffer>
+
+			<thead>
+				<%= tableHeader %>
 			</thead>
+
+
+			<c:if test="<%= fixedHeader %>">
+				<thead class="lfr-search-iterator-fixed-header hide" id="<%= namespace + id %>fixedHeader">
+					<%= tableHeader %>
+				</thead>
+			</c:if>
 		</c:if>
 
 		<tbody>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
@@ -174,7 +174,7 @@ if (fixedHeader) {
 			</thead>
 
 			<c:if test="<%= fixedHeader %>">
-				<thead class="hide lfr-search-iterator-fixed-header" id="<%= namespace + id %>fixedHeader">
+				<thead aria-hidden="true" class="hide lfr-search-iterator-fixed-header" id="<%= namespace + id %>fixedHeader">
 					<%= theadContent %>
 				</thead>
 			</c:if>

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -3725,6 +3725,12 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description>Whether to fix the table header to the top of page when scrolling. The default value is <![CDATA[<code>false</code>]]>.</description>
+			<name>fixedHeader</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>markupView</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/util-taglib/src/com/liferay/taglib/ui/SearchIteratorTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SearchIteratorTag.java
@@ -43,12 +43,20 @@ public class SearchIteratorTag<R> extends SearchPaginatorTag<R> {
 		return _searchResultCssClass;
 	}
 
+	public boolean isFixedHeader() {
+		return _fixedHeader;
+	}
+
 	public boolean isPaginate() {
 		return _paginate;
 	}
 
 	public void setDisplayStyle(String displayStyle) {
 		_displayStyle = displayStyle;
+	}
+
+	public void setFixedHeader(boolean fixedHeader) {
+		_fixedHeader = fixedHeader;
 	}
 
 	@Override
@@ -73,6 +81,7 @@ public class SearchIteratorTag<R> extends SearchPaginatorTag<R> {
 		super.cleanUp();
 
 		_displayStyle = DEFAULT_DISPLAY_STYLE;
+		_fixedHeader = false;
 		_markupView = null;
 		_paginate = true;
 		_resultRowSplitter = null;
@@ -103,6 +112,8 @@ public class SearchIteratorTag<R> extends SearchPaginatorTag<R> {
 		httpServletRequest.setAttribute(
 			"liferay-ui:search-iterator:displayStyle", getDisplayStyle());
 		httpServletRequest.setAttribute(
+			"liferay-ui:search-iterator:fixedHeader", String.valueOf(_fixedHeader));
+		httpServletRequest.setAttribute(
 			"liferay-ui:search-iterator:markupView", _markupView);
 		httpServletRequest.setAttribute(
 			"liferay-ui:search-iterator:paginate", String.valueOf(_paginate));
@@ -114,6 +125,7 @@ public class SearchIteratorTag<R> extends SearchPaginatorTag<R> {
 	}
 
 	private String _displayStyle = DEFAULT_DISPLAY_STYLE;
+	private boolean _fixedHeader = false;
 	private String _markupView;
 	private boolean _paginate = true;
 	private ResultRowSplitter _resultRowSplitter;

--- a/util-taglib/src/com/liferay/taglib/ui/SearchIteratorTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SearchIteratorTag.java
@@ -112,7 +112,8 @@ public class SearchIteratorTag<R> extends SearchPaginatorTag<R> {
 		httpServletRequest.setAttribute(
 			"liferay-ui:search-iterator:displayStyle", getDisplayStyle());
 		httpServletRequest.setAttribute(
-			"liferay-ui:search-iterator:fixedHeader", String.valueOf(_fixedHeader));
+			"liferay-ui:search-iterator:fixedHeader",
+			String.valueOf(_fixedHeader));
 		httpServletRequest.setAttribute(
 			"liferay-ui:search-iterator:markupView", _markupView);
 		httpServletRequest.setAttribute(
@@ -125,7 +126,7 @@ public class SearchIteratorTag<R> extends SearchPaginatorTag<R> {
 	}
 
 	private String _displayStyle = DEFAULT_DISPLAY_STYLE;
-	private boolean _fixedHeader = false;
+	private boolean _fixedHeader;
 	private String _markupView;
 	private boolean _paginate = true;
 	private ResultRowSplitter _resultRowSplitter;

--- a/util-taglib/src/com/liferay/taglib/ui/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/ui/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0


### PR DESCRIPTION
This is an update for [LPS-95558](https://issues.liferay.com/browse/LPS-95558).<br><br>/cc @pei-jung @stsquared99 @alee8888 @ChrisKian @dejuknow @travisrcory