### PR TITLE
LPS-95390 Unconfigured portlet-toppers should show above Control Menu

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_generic_portlet.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_generic_portlet.scss
@@ -10,6 +10,6 @@
 	}
 }
 
-.lfr-checkbox-preselected, .lfr-configurator-visibility {
+.lfr-checkbox-preselected {
 	opacity: 0.5;
 }

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_topper.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_topper.scss
@@ -138,6 +138,26 @@
 	}
 }
 
+.lfr-configurator-visibility {
+	@include media-query(null, $screen-xs-max) {
+		opacity: 0.5;
+	}
+
+	@include media-query(sm) {
+		.portlet {
+			&:hover, &.focus, &.open {
+				.portlet-topper {
+					opacity: 0.5;
+				}
+			}
+		}
+
+		.portlet-content-editable {
+			opacity: 0.5;
+		}
+	}
+}
+
 /* ---------- Portlet controls in mobile ---------- */
 
 .controls-visible {


### PR DESCRIPTION
@jonmak08 @oliv-yu This should make the portlet-topper appear above the Control Menu for unconfigured portlets. Setting `opacity` to anything less than 1 sets the stacking order of an element to 0. See https://www.w3.org/TR/css-color-3#transparency