### PR TITLE
[TECHNICAL-SUPPORT] LPS-99836

### DIFF
--- a/modules/apps/frontend-js/frontend-js-top-head-extender/src/main/java/com/liferay/frontend/js/top/head/extender/internal/servlet/taglib/TopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-top-head-extender/src/main/java/com/liferay/frontend/js/top/head/extender/internal/servlet/taglib/TopHeadDynamicInclude.java
@@ -241,9 +241,13 @@ public class TopHeadDynamicInclude implements DynamicInclude {
 			httpServletRequest, "/combo", "minifierType=js", jsLastModified);
 
 		for (String url : urls) {
-			if (sb.length() == 0) {
-				sb.append("<script data-senna-track=\"permanent\" src=\"");
+			if ((sb.length() + url.length() + 1) >= 2048) {
+				_renderScriptURL(printWriter, sb.toString());
 
+				sb = new StringBundler();
+			}
+
+			if (sb.length() == 0) {
 				AbsolutePortalURLBuilder absolutePortalURLBuilder =
 					_absolutePortalURLBuilderFactory.
 						getAbsolutePortalURLBuilder(httpServletRequest);
@@ -256,14 +260,6 @@ public class TopHeadDynamicInclude implements DynamicInclude {
 
 			sb.append(StringPool.AMPERSAND);
 			sb.append(url);
-
-			if (sb.length() >= 2048) {
-				sb.append("\" type = \"text/javascript\"></script>");
-
-				printWriter.println(sb.toString());
-
-				sb = new StringBundler();
-			}
 		}
 
 		if (sb.length() > 0) {

--- a/modules/apps/frontend-js/frontend-js-top-head-extender/src/main/java/com/liferay/frontend/js/top/head/extender/internal/servlet/taglib/TopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-top-head-extender/src/main/java/com/liferay/frontend/js/top/head/extender/internal/servlet/taglib/TopHeadDynamicInclude.java
@@ -267,9 +267,7 @@ public class TopHeadDynamicInclude implements DynamicInclude {
 		}
 
 		if (sb.length() > 0) {
-			sb.append("\" type = \"text/javascript\"></script>");
-
-			printWriter.println(sb.toString());
+			_renderScriptURL(printWriter, sb.toString());
 		}
 	}
 
@@ -281,19 +279,22 @@ public class TopHeadDynamicInclude implements DynamicInclude {
 		PrintWriter printWriter = httpServletResponse.getWriter();
 
 		for (String url : urls) {
-			printWriter.print("<script data-senna-track=\"permanent\" src=\"");
-
 			AbsolutePortalURLBuilder absolutePortalURLBuilder =
 				_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
 					httpServletRequest);
 
-			printWriter.print(
-				absolutePortalURLBuilder.forResource(
-					url
-				).build());
+			url = absolutePortalURLBuilder.forResource(
+				url
+			).build();
 
-			printWriter.println("\" type=\"text/javascript\"></script>");
+			_renderScriptURL(printWriter, url);
 		}
+	}
+
+	private void _renderScriptURL(PrintWriter printWriter, String url) {
+		printWriter.print("<script data-senna-track=\"permanent\" src=\"");
+		printWriter.print(url);
+		printWriter.println("\" type=\"text/javascript\"></script>");
 	}
 
 	@Reference


### PR DESCRIPTION
From @joshuacords:

> [LPS-99836](https://issues.liferay.com/browse/LPS-99836)
> [LPP-34555](https://issues.liferay.com/browse/LPP-34555)
> [PTR-1102](https://issues.liferay.com/browse/PTR-1102)
> 
> **Problem**: renderBundleComboURLs can exceed maximum size, sometimes causing js not to load in IE11. Because the cutoff can occur at different places based on all aspects of the URL and other parameters, it can be difficult to reproduce. I reproduced it on 7.1 @ bedf729391ee066dbb3c94cce2faf187665fcbf4, but the code creating this issue is also present in master.
> 
> **Solution**: Check the potential URL length before adding the next URL. I also extracted a method.