### PR TITLE
[TS] LPS-102195

### DIFF
--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-rotate/src/main/resources/META-INF/resources/RotateComponent.soy
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-rotate/src/main/resources/META-INF/resources/RotateComponent.soy
@@ -8,13 +8,13 @@
  */
 {template .render}
 	<div id="{$ref}">
-		<a class="btn btn-link icon-monospaced" data-onclick="rotateLeft" href="javascript:;">
+		<a class="btn btn-link btn-monospaced" data-onclick="rotateLeft" href="javascript:;">
 			<svg class="lexicon-icon">
 				<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#reply"></use>
 			</svg>
 		</a>
 
-		<a class="btn btn-link icon-monospaced" data-onclick="rotateRight" href="javascript:;">
+		<a class="btn btn-link btn-monospaced" data-onclick="rotateRight" href="javascript:;">
 			<svg class="lexicon-icon" style="transform: scaleX(-1);">
 				<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#reply"></use>
 			</svg>


### PR DESCRIPTION
From @jesseyeh-liferay:

> ## Problem :grimacing:
> 
> **[LPS-102195](https://issues.liferay.com/browse/LPS-102195)**
> 
> The rotate buttons are misaligned in the image editor.
> 
> ## Analysis :nerd_face:
> 
> `.btn-monospaced` is another modifier class that aligns the buttons correctly. Differences between it and `icon-monospaced` are detailed in the following table -- visual parity can be achieved by making edits to `clay.css`:
> 
> | `btn-monospaced` | `icon-monospaced` |
> | --- | --- |
> | **`.btn-monospaced`**:<br><br>`padding-left: 0`<br>`padding-right: 0`<br>`padding-top: 0.25rem`<br>`padding-bottom: 0.25rem`<br><br>`width: 2.5rem`<br>`height: 2.5rem` | **`.icon-monospaced, .icon-monospaced[class^='icon-'], .icon-monospaced[class*=' icon-']`**:<br><br>No padding<br><br>`width: 2rem`<br>`height: 2rem` |
> | **`a.btn-monospaced, span.btn-monospaced`**:<br><br>`line-height: inherit` | **`.icon-monospaced, .icon-monospaced[class^='icon-'], .icon-monospaced[class*=' icon-']`**:<br><br>`line-height: 34px` |
> | **`.btn-monospaced.btn .lexicon-icon`**:<br><br>`margin-top: 0` | **`.lexicon-icon`**:<br><br>`margin-top: -3px` |
> 
> ## Solution :tada:
> 
> Instead of using the original `icon-monospaced` modifier class, we instead use `btn-monospaced` to fix the button alignment.

CC @wanderlast