### PR TITLE
LPS-109906 Also set the top position of the modal window

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
@@ -518,12 +518,13 @@ AUI.add(
 
 				instance._setWindowDefaultSizeIfNeeded(modal);
 
-				// LPS-106470 resize modal mask
+				// LPS-106470, LPS-109906 resize modal mask
 
 				var mask = modal.get('maskNode');
 
 				if (mask.getStyle('position') == 'absolute') {
 					mask.setStyle('height', '100%');
+					mask.setStyle('top', document.documentElement.scrollTop + 'px');
 					mask.setStyle('width', '100%');
 				}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-109906

In my testing, if I scrolled to the right (I tested by adding an oversized image to web content and setting a style of `max-width: 500%` to override the normal image styling of web content), the window always snapped back to the left when I opened a modal dialog, so a left positioning was not needed.