### PR TITLE
[TS] LPS-119092

### DIFF
--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
@@ -52,6 +52,7 @@ function PersonalMenu({
 					/>
 				) : (
 					<ClayButton
+						aria-label={Liferay.language.get('user-personal-panel')}
 						displayType="unstyled"
 						onFocus={preloadItems}
 						onMouseOver={preloadItems}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-38598
https://issues.liferay.com/browse/LPS-119092

From @wanderlast

> The fix is straightforward: the button is missing an aria-label. The only issue that I think may come up is what is being used as the label. I am currently grabbing the term "user personal panel" from our language bundle since it already exists and is fairly close to what we're looking for here (the exact term we'd want is "personal menu"), but I was unsure if "user personal panel" referred to something specific that would confuse actual users so I wanted your input. As far as I know, the term 'user personal panel' is not currently being used in Master, but I may have missed it.
> 
> As a note, I opted for something in the language bundle since that way we'd at least have some translations existing, but a straight string can also work here.
> 
> Thanks! Let me know if you have any questions about anything.