### PR TITLE
LPS-127719 Return default sort if sort.field is not found

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/jaxrs/context/provider/SortContextProvider.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/jaxrs/context/provider/SortContextProvider.java
@@ -14,6 +14,7 @@
 
 package com.liferay.frontend.taglib.clay.internal.jaxrs.context.provider;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.SortFactoryUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -45,7 +46,12 @@ public class SortContextProvider implements ContextProvider<Sort> {
 			httpServletRequest, "sort.field");
 
 		if (Validator.isNull(sortString)) {
-			return null;
+			sortString = ParamUtil.getString(httpServletRequest, "sort");
+
+			String[] sortArray = StringUtil.split(sortString, StringPool.COLON);
+
+			return SortFactoryUtil.create(
+				StringUtil.trim(sortArray[0]), sortArray[1].equals("desc"));
 		}
 
 		String sortDir = ParamUtil.getString(httpServletRequest, "sort.dir");


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-127719

When using the Clay:data-set-display tag, the sort parameter always return null if `sort.field` is not passed. Instead of making it unavailable to the user, return `sort` which contains `name:desc` so the user is able to use the sort parameter when calling [`getItems`](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/data/set/provider/ClayDataSetDataProvider.java#L34)

Let me know if there are any questions or comments about this.
Thank you.