### PR TITLE
LPS-126178 Add max-width to truncate tree node text

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
@@ -130,6 +130,10 @@ $product-menu-pages-administration-link-height: 72px;
 				}
 			}
 
+			.table-cell-content {
+				max-width: 175px;
+			}
+
 			.tree-node .tree-node-content {
 				align-items: center;
 				display: flex;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-126178

If the page name is too long, a horizontal scroll bar appears and the ellipses cannot be seen unless scrolled. A solution to this would be to truncate the text. I set a max-width to `175px` specifically so the ellipses matches correctly to the others and provides the most view of the word.

Please let me know if there are any questions or comments about this.
Thank you.