### PR TITLE
LPS-131748 MB replies should scroll to text field in mobile and browsers

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
@@ -121,7 +121,7 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 						editor.focus();
 					});
 
-					if (addQuickReplyContainer && AUI().UA.mobile) {
+					if (addQuickReplyContainer) {
 						addQuickReplyContainer.scrollIntoView(true);
 					}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-131748

The issue lies in the Message Board Thread not scrolling into view when clicking Reply or Reply with Quote. This issue was fixed in browser since it was more noticeable as an issue. By removing the mobile condition, we can see the jump to the text field in both browser and mobile.

Let me know if there are any questions or comments about this.
Thank you.