### PR TITLE
LPS-132211 Fix blog card overflow for Time To Read

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/components/_widget.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/components/_widget.scss
@@ -61,6 +61,7 @@
 		margin-bottom: 16px;
 
 		.inline-item-before {
+			flex-shrink: 1;
 			margin-right: 1rem;
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-132211

When 'Time to Read' for blogs is turned on and Blog portlet is placed in a 30 column, the 'Time to Read' overflows out of the card. I found that adding `flex-shrink: 1` contains the 'Time to Read' in the portlet and should not affect other content.
Let me know if there are any questions or comments about this.

Thank you.