### PR TITLE
LPS-132211 Adjust markup for blogs using Time To Read

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/common_main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/common_main.scss
@@ -99,6 +99,12 @@
 		}
 	}
 
+	.widget-mode-card {
+		.card {
+			max-width: 65%;
+		}
+	}
+
 	.widget-mode-simple-entry {
 		.widget-content {
 			img {

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry.jsp
@@ -102,9 +102,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 						<strong><liferay-ui:message key="more-blog-entries" /></strong>
 					</h2>
 
-					<clay:row
-						cssClass="widget-mode-card"
-					>
+					<div class="widget-mode-card">
 
 						<%
 						request.setAttribute("view_entry_related.jsp-blogs_entry", previousEntry);
@@ -117,7 +115,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 						%>
 
 						<liferay-util:include page="/blogs/view_entry_related.jsp" servletContext="<%= application %>" />
-					</clay:row>
+					</div>
 				</clay:col>
 			</clay:row>
 		</c:if>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_related.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_related.jsp
@@ -25,110 +25,102 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 %>
 
 <c:if test="<%= blogsEntry != null %>">
-	<clay:col
-		lg="6"
-	>
-		<div class="card">
+	<div class="card">
 
-			<%
-			String imageURL = blogsEntry.getCoverImageURL(themeDisplay);
+		<%
+		String imageURL = blogsEntry.getCoverImageURL(themeDisplay);
 
-			if (Validator.isNull(imageURL)) {
-				imageURL = blogsEntry.getSmallImageURL(themeDisplay);
-			}
+		if (Validator.isNull(imageURL)) {
+			imageURL = blogsEntry.getSmallImageURL(themeDisplay);
+		}
 
-			if (Validator.isNull(imageURL)) {
-				imageURL = PortalUtil.getPathContext(request) + "/images/cover_image_placeholder.jpg";
-			}
-			%>
+		if (Validator.isNull(imageURL)) {
+			imageURL = PortalUtil.getPathContext(request) + "/images/cover_image_placeholder.jpg";
+		}
+		%>
 
-			<div class="card-header">
-				<div class="aspect-ratio aspect-ratio-8-to-3">
-					<img alt="thumbnail" class="aspect-ratio-item-center-middle aspect-ratio-item-fluid" src="<%= HtmlUtil.escape(imageURL) %>" />
-				</div>
-			</div>
-
-			<div class="card-body widget-topbar">
-				<clay:content-row
-					cssClass=" card-title"
-				>
-					<clay:content-col
-						expand="<%= true %>"
-					>
-						<portlet:renderURL var="blogsEntryURL">
-							<portlet:param name="mvcRenderCommandName" value="/blogs/view_entry" />
-							<portlet:param name="redirect" value="<%= redirect %>" />
-							<portlet:param name="urlTitle" value="<%= blogsEntry.getUrlTitle() %>" />
-						</portlet:renderURL>
-
-						<liferay-util:html-top
-							outputKey="blogs_previous_entry_link"
-						>
-							<link href="<%= blogsEntryURL.toString() %>" rel="prev" />
-						</liferay-util:html-top>
-
-						<h3 class="title"><a class="title-link" href="<%= blogsEntryURL %>">
-							<%= HtmlUtil.escape(BlogsEntryUtil.getDisplayTitle(resourceBundle, blogsEntry)) %></a>
-						</h3>
-					</clay:content-col>
-				</clay:content-row>
-
-				<clay:content-row
-					cssClass="widget-metadata"
-				>
-
-					<%
-					User blogsEntryUser = UserLocalServiceUtil.fetchUser(blogsEntry.getUserId());
-
-					String blogsEntryUserURL = StringPool.BLANK;
-
-					if ((blogsEntryUser != null) && !blogsEntryUser.isDefaultUser() && !user.isDefaultUser()) {
-						blogsEntryUserURL = blogsEntryUser.getDisplayURL(themeDisplay);
-					}
-					%>
-
-					<clay:content-col
-						cssClass="inline-item-before"
-					>
-						<liferay-ui:user-portrait
-							user="<%= blogsEntryUser %>"
-						/>
-					</clay:content-col>
-
-					<clay:content-col
-						cssClass="inline-item-before"
-					>
-						<clay:content-row>
-							<clay:content-col
-								cssClass="inline-item-before"
-							>
-								<div class="text-truncate-inline">
-									<a class="text-truncate username" href="<%= blogsEntryUserURL %>"><%= HtmlUtil.escape(blogsEntry.getUserName()) %></a>
-								</div>
-
-								<div class="text-secondary">
-									<%= DateUtil.getDate(blogsEntry.getStatusDate(), "dd MMM", locale) %>
-
-									<c:if test="<%= blogsPortletInstanceConfiguration.enableReadingTime() %>">
-										- <liferay-reading-time:reading-time displayStyle="descriptive" model="<%= blogsEntry %>" />
-									</c:if>
-								</div>
-							</clay:content-col>
-						</clay:content-row>
-					</clay:content-col>
-				</clay:content-row>
-			</div>
-
-			<div class="card-footer">
-
-				<%
-				request.setAttribute("entry_toolbar.jsp-entry", blogsEntry);
-				%>
-
-				<liferay-util:include page="/blogs/entry_toolbar.jsp" servletContext="<%= application %>">
-					<liferay-util:param name="showOnlyIcons" value="<%= Boolean.TRUE.toString() %>" />
-				</liferay-util:include>
+		<div class="card-header">
+			<div class="aspect-ratio aspect-ratio-8-to-3">
+				<img alt="thumbnail" class="aspect-ratio-item-center-middle aspect-ratio-item-fluid" src="<%= HtmlUtil.escape(imageURL) %>" />
 			</div>
 		</div>
-	</clay:col>
+
+		<div class="card-body widget-topbar">
+			<clay:content-row
+				cssClass=" card-title"
+			>
+				<clay:content-col
+					expand="<%= true %>"
+				>
+					<portlet:renderURL var="blogsEntryURL">
+						<portlet:param name="mvcRenderCommandName" value="/blogs/view_entry" />
+						<portlet:param name="redirect" value="<%= redirect %>" />
+						<portlet:param name="urlTitle" value="<%= blogsEntry.getUrlTitle() %>" />
+					</portlet:renderURL>
+
+					<liferay-util:html-top
+						outputKey="blogs_previous_entry_link"
+					>
+						<link href="<%= blogsEntryURL.toString() %>" rel="prev" />
+					</liferay-util:html-top>
+
+					<h3 class="title"><a class="title-link" href="<%= blogsEntryURL %>">
+						<%= HtmlUtil.escape(BlogsEntryUtil.getDisplayTitle(resourceBundle, blogsEntry)) %></a>
+					</h3>
+				</clay:content-col>
+			</clay:content-row>
+
+			<clay:content-row
+				cssClass="autofit-padded-no-gutters widget-metadata"
+			>
+
+				<%
+				User blogsEntryUser = UserLocalServiceUtil.fetchUser(blogsEntry.getUserId());
+
+				String blogsEntryUserURL = StringPool.BLANK;
+
+				if ((blogsEntryUser != null) && !blogsEntryUser.isDefaultUser() && !user.isDefaultUser()) {
+					blogsEntryUserURL = blogsEntryUser.getDisplayURL(themeDisplay);
+				}
+				%>
+
+				<clay:content-col
+					cssClass="autofit-col-expand"
+				>
+					<liferay-ui:user-portrait
+						user="<%= blogsEntryUser %>"
+					/>
+				</clay:content-col>
+
+				<clay:content-col
+					cssClass="autofit-col-expand"
+				>
+					<clay:content-section>
+						<div class="text-truncate-inline">
+							<a class="text-truncate username" href="<%= blogsEntryUserURL %>"><%= HtmlUtil.escape(blogsEntry.getUserName()) %></a>
+						</div>
+
+						<div class="text-secondary">
+							<%= DateUtil.getDate(blogsEntry.getStatusDate(), "dd MMM", locale) %>
+
+							<c:if test="<%= blogsPortletInstanceConfiguration.enableReadingTime() %>">
+								- <liferay-reading-time:reading-time displayStyle="descriptive" model="<%= blogsEntry %>" />
+							</c:if>
+						</div>
+					</clay:content-section>
+				</clay:content-col>
+			</clay:content-row>
+		</div>
+
+		<div class="card-footer">
+
+			<%
+			request.setAttribute("entry_toolbar.jsp-entry", blogsEntry);
+			%>
+
+			<liferay-util:include page="/blogs/entry_toolbar.jsp" servletContext="<%= application %>">
+				<liferay-util:param name="showOnlyIcons" value="<%= Boolean.TRUE.toString() %>" />
+			</liferay-util:include>
+		</div>
+	</div>
 </c:if>


### PR DESCRIPTION
http://issues.liferay.com/browse/LPS-132211.

When the “Time To Read” option is selected for blogs, the words overflow the card when the blogs widget is placed in the 30 column of a 30/70 page.

Hello @jonmak08,

I implemented the [changes provided to me here.](https://github.com/liferay-frontend/liferay-portal/pull/1064#issuecomment-841539071)
I was unsure of the max-width but settled with `max-width: 65%` as it looked the best to me in different containers. Let me know if there is anything that needs adjusting.

Thank you.